### PR TITLE
Add arch/guild/lightning data, wiki sync script, and build path fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules/
 .env
 build/
 *.tsbuildinfo
+
+# Accidental tsc output next to sources (canonical build is build/)
+src/*.js
+src/*.js.map
+src/*.d.ts
+!src/types.d.ts

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Discord TR Bot
+
 This is a chat-bot for analyzing the game [The Reincarnation](https://www.the-reincarnation.com/about.php), an online game where one plays the role of an ancient mage. The bot here is used to analyze unit pairings, their strengths/weakness, and other statistical shenanigans.
 
-
 ## Creating a Bot
+
 You need to first apply for a bot-application on Discord [here](https://discord.com/developers/applications)
 
 The bot will need privilege to access guild messages and reply to messages. Once the privileges are enabled the bot will need to be authorized onto specific server(s) via the generated OAuth URL.
@@ -10,16 +11,13 @@ The bot will need privilege to access guild messages and reply to messages. Once
 We also need to grab the access `TOKEN` that will allow the bot to sign-on.
 
 ## Run the Bot
-This depends on node-22/24 and `discord.js`. 
+
+This depends on node-16/18 and `discord.js`. 
+
 - Create a `.env` file and put the discord developer app [TOKEN](https://discordjs.guide/preparations/setting-up-a-bot-application.html#what-is-a-token-anyway) into it
 
 ```
 TOKEN=<access token>
-
-# optionally to have AI/LLM
-AI_TOKEN=<ai_token>
-AI_URL=<url>
-AI_SERVERS=<list of discord server ids, comma delimited>
 ```
 
 - Install dependencies: `npm install`
@@ -27,28 +25,26 @@ AI_SERVERS=<list of discord server ids, comma delimited>
 - Run the bot: `npm start`
 
 ## Features
+
 - Match up smulation to both prognose and diagnose 
 - Pairwise analysis for finding best offensive and defensive pairings
 - Language features to allow for short names, spelling variations and mistakes
 
-
 ## Interacting with the Bot
+
 The follow analysis directives are supported
+
 - show match {unit1} vs {unit2}
 - show battle {unit1} vs {unit2}
 - show pairing {unit}
 
 The following configurations directives are available
+
 - show config
 - set server
 
-## Misc.
-Get short answers from AI/LLM
-- ask {prompt} 
-
-
-
 ### Head-to-head match up
+
 Runs head-to-head simulation match up between two units
 
 ```
@@ -69,8 +65,8 @@ Lich loss 44.7% = 441/986 (893299 np)
 Dominion loss 5.9% = 3/51 (117039 np)
 ```
 
-
 ### Best unit
+
 Run pairwise simulations to determine the best offensive and defensive units.
 
 ```
@@ -110,8 +106,8 @@ Phantasm: ^Yeti, Leviathan, Ice Elemental
 ^ Deals 5% or more damage than it receives (good head-to-head)
 ```
 
-
 ### Show single battle
+
 Runs a single battle with detailed logs
 
 ```
@@ -140,3 +136,4 @@ Defender lost 463 Dwarven Shaman
 Attacker loss np 464400
 Defender loss np 463000
 ```
+

--- a/data/arch/enchantments.json
+++ b/data/arch/enchantments.json
@@ -1,0 +1,234 @@
+[
+  {
+    "id": "thl",
+    "name": "The holy light",
+    "magic": "ascendant",
+    "effects": [
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null, 
+          "value": 0.1263
+        }
+      },
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["accuracy"],
+          "type": "change value",
+          "base": 1,
+          "value": 0.06315
+        }
+      },
+      {
+        "filters": [
+          {
+            "magic": "ascendant",
+            "primaryTypes": ["melee"]
+          },
+          {
+            "magic": "ascendant",
+            "secondaryTypes": ["melee"]
+          }
+        ],
+        "action": {
+          "attributes": ["primaryTypes"],
+          "type": "add attack type",
+          "value": "holy"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lnp",
+    "name": "Love and Peace",
+    "magic": "ascendant",
+    "effects": [
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": -0.2
+        }
+      },
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.25
+        }
+      }
+    ]
+  },
+  {
+    "id": "lore",
+    "name": "Nature's Lore",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["elf"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.13
+        }
+      },
+      {
+        "filters": [
+          { "race": ["elf"] }
+        ],
+        "action": {
+          "attributes": ["accuracy"],
+          "type": "change value",
+          "base": 1,
+          "value": 0.07
+        }
+      },
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.25
+        }
+      },
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.20
+        }
+      }
+    ]
+  },
+  {
+    "id": "pg",
+    "name": "Plant Growth",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["treefolk"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "counterPower", "hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.9524
+        }
+      }
+    ]
+  },
+  {
+    "id": "ea",
+    "name": "Enlarge Animal",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.47
+        }
+      }
+    ]
+  },
+  {
+    "id": "bc",
+    "name": "Battle Chant",
+    "magic": "eradication",
+    "effects": [
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.2
+        }
+      },
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": -0.1
+        }
+      }
+    ]
+  },
+  {
+    "id": "bs",
+    "name": "Black Sabbath",
+    "magic": "nether",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["demon"] }
+        ],
+        "action": {
+          "attributes": ["resistances.holy"],
+          "type": "change value",
+          "base": 100,
+          "value": 0.329
+        }
+      },
+      {
+        "filters": [
+          { "race": ["undead"] }
+        ],
+        "action": {
+          "attributes": ["resistances.holy"],
+          "type": "change value",
+          "base": 100,
+          "value": 0.329
+        }
+      }
+    ]
+  },
+  {
+    "id": "hallu",
+    "name": "Hallucination",
+    "magic": "phantasm",
+    "effects": [
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["efficiency"],
+          "type": "change value",
+          "base": 100,
+          "value": -0.1
+        }
+      }
+    ]
+  }
+]

--- a/data/arch/units.json
+++ b/data/arch/units.json
@@ -1,46 +1,5 @@
 [
     {
-        "name": "Air Elemental",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 25000,
-        "hp": 60000,
-        "a1_power": 300000,
-        "a1_type": "lightning ranged",
-        "a1_init": 4,
-        "counter": 6500,
-        "a2_power": 200000,
-        "a2_type": "magic",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 95,
-            "fire": 50,
-            "poison": 0,
-            "breath": 70,
-            "magic": 55,
-            "melee": 95,
-            "ranged": 95,
-            "lightning": 100,
-            "cold": 0,
-            "paralyse": 20,
-            "psychic": 50,
-            "holy": 80
-        },
-        "abilities": [
-            "flying",
-            "swift"
-        ]
-    },
-    {
         "name": "Angel",
         "magic": "ascendant",
         "race": [
@@ -245,48 +204,6 @@
         ]
     },
     {
-        "name": "Bulwark Horror",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 2018,
-        "hp": 10750,
-        "a1_power": 13600,
-        "a1_type": "melee poison",
-        "a1_init": 1,
-        "counter": 4900,
-        "a2_power": 9000,
-        "a2_type": "cold ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 0,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 40,
-            "fire": 60,
-            "poison": 50,
-            "breath": 70,
-            "magic": 20,
-            "melee": 90,
-            "ranged": 40,
-            "lightning": 30,
-            "cold": 40,
-            "paralyse": 30,
-            "psychic": 30,
-            "holy": 50
-        },
-        "abilities": [
-            "endurance",
-            "large shield",
-            "pike"
-        ]
-    },
-    {
         "name": "Capsule Monster",
         "magic": "plain",
         "race": [
@@ -408,6 +325,47 @@
         ]
     },
     {
+        "name": "Cave Troll",
+        "magic": "nether",
+        "race": [
+            "troll"
+        ],
+        "power": 49,
+        "hp": 400,
+        "a1_power": 400,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 100,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "regeneration",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
         "name": "Chimera",
         "magic": "eradication",
         "race": [
@@ -426,7 +384,7 @@
             "ascendant": 0,
             "verdant": 0,
             "eradication": 50,
-            "nether": 0,
+            "nether": 25,
             "phantasm": 0
         },
         "resistances": {
@@ -491,6 +449,47 @@
         ]
     },
     {
+        "name": "Crusader",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 14,
+        "hp": 130,
+        "a1_power": 160,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 40,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed 50%"
+        ]
+    },
+    {
         "name": "Dark Apprentice",
         "magic": "nether",
         "race": [
@@ -530,47 +529,6 @@
             "marksmanship",
             "recruit speed -10%",
             "swift"
-        ]
-    },
-    {
-        "name": "Dark Elemental",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 20586,
-        "hp": 80000,
-        "a1_power": 100000,
-        "a1_type": "paralyse",
-        "a1_init": 1,
-        "counter": 15000,
-        "a2_power": 300000,
-        "a2_type": "paralyse ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 0,
-            "eradication": 40,
-            "nether": 80,
-            "phantasm": 80
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 60,
-            "poison": 90,
-            "breath": 50,
-            "magic": 60,
-            "melee": 100,
-            "ranged": 85,
-            "lightning": 50,
-            "cold": 50,
-            "paralyse": 100,
-            "psychic": 50,
-            "holy": 20
-        },
-        "abilities": [
-            "endurance",
-            "steal life 5%"
         ]
     },
     {
@@ -631,19 +589,19 @@
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 25,
-            "eradication": 60,
-            "nether": 0,
+            "eradication": 70,
+            "nether": 50,
             "phantasm": 20
         },
         "resistances": {
             "missile": 70,
-            "fire": 75,
+            "fire": 60,
             "poison": 75,
-            "breath": 0,
+            "breath": 50,
             "magic": 60,
             "melee": 85,
             "ranged": 70,
-            "lightning": 70,
+            "lightning": 0,
             "cold": 75,
             "paralyse": 60,
             "psychic": 50,
@@ -703,7 +661,7 @@
         "race": [
             "elemental"
         ],
-        "power": 1550,
+        "power": 1700,
         "hp": 7650,
         "a1_power": 8000,
         "a1_type": "magic",
@@ -739,44 +697,43 @@
         ]
     },
     {
-        "name": "Dominion",
-        "magic": "ascendant",
+        "name": "Druid",
+        "magic": "verdant",
         "race": [
-            "angel"
+            "elf"
         ],
-        "power": 39013,
-        "hp": 80000,
-        "a1_power": 200000,
-        "a1_type": "holy",
-        "a1_init": 2,
-        "counter": 30000,
-        "a2_power": 250000,
-        "a2_type": "holy",
-        "a2_init": 3,
+        "power": 40,
+        "hp": 180,
+        "a1_power": 440,
+        "a1_type": "magic ranged",
+        "a1_init": 3,
+        "counter": 60,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
-            "eradication": 80,
-            "nether": 80,
-            "phantasm": 50
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 25
         },
         "resistances": {
-            "missile": 85,
-            "fire": 85,
-            "poison": 85,
-            "breath": 85,
-            "magic": 85,
-            "melee": 85,
-            "ranged": 85,
-            "lightning": 85,
-            "cold": 85,
-            "paralyse": 85,
-            "psychic": 85,
-            "holy": 80
+            "missile": 50,
+            "fire": 25,
+            "poison": 90,
+            "breath": 0,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 25,
+            "cold": 25,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 25
         },
         "abilities": [
-            "flying",
-            "healing"
+            "recruit speed -15%"
         ]
     },
     {
@@ -818,46 +775,6 @@
         "abilities": [
             "beauty",
             "charm"
-        ]
-    },
-    {
-        "name": "Dwarven Batrider",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 24,
-        "hp": 180,
-        "a1_power": 120,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
         ]
     },
     {
@@ -943,46 +860,6 @@
         ]
     },
     {
-        "name": "Dwarven Gunslinger",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 18,
-        "hp": 130,
-        "a1_power": 90,
-        "a1_type": "missile ranged",
-        "a1_init": 4,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "piercing"
-        ]
-    },
-    {
         "name": "Dwarven Shaman",
         "magic": "eradication",
         "race": [
@@ -1023,43 +900,45 @@
         ]
     },
     {
-        "name": "Earth Elemental",
-        "magic": "verdant",
+        "name": "Dwarven Warrior",
+        "magic": "eradication",
         "race": [
-            "elemental"
+            "dwarf"
         ],
-        "power": 22000,
-        "hp": 100000,
-        "a1_power": 100000,
+        "power": 20,
+        "hp": 160,
+        "a1_power": 200,
         "a1_type": "melee",
         "a1_init": 1,
-        "counter": 15000,
-        "a2_power": 550000,
-        "a2_type": "magic ranged",
-        "a2_init": 3,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
         "spell_resistance": {
             "ascendant": 0,
-            "verdant": 40,
-            "eradication": 50,
-            "nether": 60,
-            "phantasm": 40
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
         },
         "resistances": {
-            "missile": 90,
-            "fire": 50,
-            "poison": 100,
-            "breath": 60,
-            "magic": 50,
-            "melee": 90,
-            "ranged": 70,
-            "lightning": 50,
-            "cold": 40,
-            "paralyse": 95,
-            "psychic": 80,
-            "holy": 80
+            "missile": 0,
+            "fire": 0,
+            "poison": 25,
+            "breath": 0,
+            "magic": 15,
+            "melee": 25,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 10
         },
         "abilities": [
-            "endurance"
+            "racial enemy against orc 50%",
+            "endurance",
+            "recruit speed 30%"
         ]
     },
     {
@@ -1093,15 +972,16 @@
             "melee": 60,
             "ranged": 75,
             "lightning": 75,
-            "cold": 75,
+            "cold": 30,
             "paralyse": 45,
             "psychic": 0,
-            "holy": 50
+            "holy": 40
         },
         "abilities": [
             "fear",
             "marksmanship",
-            "swift"
+            "swift",
+            "weakness to attacktype cold"
         ]
     },
     {
@@ -1234,88 +1114,6 @@
         ]
     },
     {
-        "name": "Elven Scout",
-        "magic": "verdant",
-        "race": [
-            "elf"
-        ],
-        "power": 20,
-        "hp": 120,
-        "a1_power": 80,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 30,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "-"
-        ]
-    },
-    {
-        "name": "Empyrean Inquisitor",
-        "magic": "ascendant",
-        "race": [
-            "astral"
-        ],
-        "power": 2500,
-        "hp": 9000,
-        "a1_power": 13500,
-        "a1_type": "magic",
-        "a1_init": 4,
-        "counter": 1900,
-        "a2_power": 2500,
-        "a2_type": "melee",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 30,
-            "nether": 50,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 75,
-            "poison": 0,
-            "breath": 35,
-            "magic": 75,
-            "melee": 80,
-            "ranged": 70,
-            "lightning": 20,
-            "cold": 10,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 30
-        },
-        "abilities": [
-            "charm",
-            "fear",
-            "weakness to attacktype poison"
-        ]
-    },
-    {
         "name": "Faerie Dragon",
         "magic": "verdant",
         "race": [
@@ -1427,7 +1225,7 @@
             "magic": 50,
             "melee": 50,
             "ranged": 50,
-            "lightning": 55,
+            "lightning": 50,
             "cold": 50,
             "paralyse": 25,
             "psychic": 50,
@@ -1469,7 +1267,7 @@
             "magic": 75,
             "melee": 75,
             "ranged": 75,
-            "lightning": 80,
+            "lightning": 75,
             "cold": 75,
             "paralyse": 25,
             "psychic": 75,
@@ -1511,7 +1309,7 @@
             "magic": 85,
             "melee": 85,
             "ranged": 85,
-            "lightning": 90,
+            "lightning": 85,
             "cold": 85,
             "paralyse": 85,
             "psychic": 85,
@@ -1532,7 +1330,7 @@
         ],
         "power": 12,
         "hp": 500,
-        "a1_power": 300,
+        "a1_power": 500,
         "a1_type": "holy",
         "a1_init": 1,
         "counter": 500,
@@ -1562,47 +1360,6 @@
         },
         "abilities": [
             "additional strike"
-        ]
-    },
-    {
-        "name": "Fire Elemental",
-        "magic": "eradication",
-        "race": [
-            "elemental"
-        ],
-        "power": 21000,
-        "hp": 85000,
-        "a1_power": 100000,
-        "a1_type": "fire",
-        "a1_init": 1,
-        "counter": 9000,
-        "a2_power": 300000,
-        "a2_type": "fire ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 80,
-            "eradication": 80,
-            "nether": 80,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 100,
-            "fire": 100,
-            "poison": 95,
-            "breath": 100,
-            "magic": 50,
-            "melee": 85,
-            "ranged": 75,
-            "lightning": 60,
-            "cold": 20,
-            "paralyse": 100,
-            "psychic": 40,
-            "holy": 80
-        },
-        "abilities": [
-            "endurance",
-            "weakness to attacktype cold"
         ]
     },
     {
@@ -1688,13 +1445,53 @@
         ]
     },
     {
+        "name": "Gargoyle",
+        "magic": "nether",
+        "race": [
+            "golem"
+        ],
+        "power": 64,
+        "hp": 300,
+        "a1_power": 400,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 25,
+            "melee": 25,
+            "ranged": 25,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
         "name": "Ghoul",
         "magic": "nether",
         "race": [
             "undead"
         ],
         "power": 35,
-        "hp": 400,
+        "hp": 650,
         "a1_power": 500,
         "a1_type": "melee paralyse",
         "a1_init": 1,
@@ -1715,7 +1512,7 @@
             "poison": 100,
             "breath": 0,
             "magic": 0,
-            "melee": 0,
+            "melee": 75,
             "ranged": 0,
             "lightning": 0,
             "cold": 0,
@@ -1726,48 +1523,6 @@
         "abilities": [
             "steal life 5%",
             "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Goblin",
-        "magic": "eradication",
-        "race": [
-            "orc"
-        ],
-        "power": 13,
-        "hp": 180,
-        "a1_power": 125,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 50,
-        "a2_power": 75,
-        "a2_type": "ranged missile",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 25,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 25,
-            "fire": 50,
-            "poison": 0,
-            "breath": 25,
-            "magic": 0,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "racial enemy against human 100%",
-            "clumsiness",
-            "weaken resistance to ranged"
         ]
     },
     {
@@ -1818,11 +1573,11 @@
         ],
         "power": 399,
         "hp": 3750,
-        "a1_power": 2750,
+        "a1_power": 2400,
         "a1_type": "melee",
         "a1_init": 1,
         "counter": 500,
-        "a2_power": 3450,
+        "a2_power": 3000,
         "a2_type": "melee",
         "a2_init": 3,
         "spell_resistance": {
@@ -1848,7 +1603,8 @@
         },
         "abilities": [
             "endurance",
-            "flying"
+            "flying",
+            "marksmanship"
         ]
     },
     {
@@ -1870,7 +1626,7 @@
             "ascendant": 0,
             "verdant": 0,
             "eradication": 50,
-            "nether": 0,
+            "nether": 25,
             "phantasm": 0
         },
         "resistances": {
@@ -1975,46 +1731,6 @@
         ]
     },
     {
-        "name": "Holy Spirit",
-        "magic": "ascendant",
-        "race": [
-            "elemental"
-        ],
-        "power": 29,
-        "hp": 200,
-        "a1_power": 140,
-        "a1_type": "holy",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
         "name": "Horned Demon",
         "magic": "nether",
         "race": [
@@ -2074,7 +1790,7 @@
             "ascendant": 0,
             "verdant": 33,
             "eradication": 50,
-            "nether": 0,
+            "nether": 50,
             "phantasm": 80
         },
         "resistances": {
@@ -2088,7 +1804,7 @@
             "lightning": 45,
             "cold": 0,
             "paralyse": 45,
-            "psychic": 80,
+            "psychic": 45,
             "holy": 50
         },
         "abilities": [
@@ -2096,46 +1812,6 @@
             "endurance",
             "regeneration",
             "scales",
-            "weakness to attacktype fire"
-        ]
-    },
-    {
-        "name": "Ice Elemental",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 21800,
-        "hp": 90000,
-        "a1_power": 200000,
-        "a1_type": "cold ranged",
-        "a1_init": 1,
-        "counter": 10000,
-        "a2_power": 300000,
-        "a2_type": "cold ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 85,
-            "fire": 0,
-            "poison": 100,
-            "breath": 0,
-            "magic": 75,
-            "melee": 85,
-            "ranged": 85,
-            "lightning": 80,
-            "cold": 100,
-            "paralyse": 100,
-            "psychic": 50,
-            "holy": 80
-        },
-        "abilities": [
             "weakness to attacktype fire"
         ]
     },
@@ -2180,6 +1856,47 @@
         ]
     },
     {
+        "name": "Knight",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 23,
+        "hp": 200,
+        "a1_power": 250,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed -15%"
+        ]
+    },
+    {
         "name": "Knight Templar",
         "magic": "ascendant",
         "race": [
@@ -2219,50 +1936,6 @@
             "healing",
             "large shield",
             "recruit speed -8%"
-        ]
-    },
-    {
-        "name": "Leviathan",
-        "magic": "phantasm",
-        "race": [
-            "giant"
-        ],
-        "power": 49500,
-        "hp": 100000,
-        "a1_power": 200000,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 50000,
-        "a2_power": 300000,
-        "a2_type": "poison ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 90,
-            "phantasm": 80
-        },
-        "resistances": {
-            "missile": 95,
-            "fire": 50,
-            "poison": 100,
-            "breath": 80,
-            "magic": 90,
-            "melee": 95,
-            "ranged": 95,
-            "lightning": 70,
-            "cold": 80,
-            "paralyse": 90,
-            "psychic": 70,
-            "holy": 80
-        },
-        "abilities": [
-            "additional strike",
-            "racial enemy against animal 50%",
-            "endurance",
-            "marksmanship",
-            "scales"
         ]
     },
     {
@@ -2426,7 +2099,6 @@
             "holy": 0
         },
         "abilities": [
-            "racial enemy against human 50%",
             "fear",
             "scales"
         ]
@@ -2565,7 +2237,7 @@
         "a1_type": "melee lightning",
         "a1_init": 2,
         "counter": 2500,
-        "a2_power": 17625,
+        "a2_power": 17600,
         "a2_type": "lightning",
         "a2_init": 2,
         "spell_resistance": {
@@ -2642,8 +2314,8 @@
             "giant"
         ],
         "power": 34,
-        "hp": 700,
-        "a1_power": 300,
+        "hp": 300,
+        "a1_power": 400,
         "a1_type": "melee",
         "a1_init": 2,
         "counter": 100,
@@ -2672,7 +2344,6 @@
             "holy": 0
         },
         "abilities": [
-            "clumsiness",
             "endurance",
             "recruit speed 10%"
         ]
@@ -2923,48 +2594,6 @@
         ]
     },
     {
-        "name": "Phoenix",
-        "magic": "verdant",
-        "race": [
-            "elemental"
-        ],
-        "power": 36883,
-        "hp": 70000,
-        "a1_power": 200000,
-        "a1_type": "magic",
-        "a1_init": 1,
-        "counter": 40000,
-        "a2_power": 600000,
-        "a2_type": "magic ranged",
-        "a2_init": 5,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 50
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 100,
-            "poison": 80,
-            "breath": 80,
-            "magic": 80,
-            "melee": 90,
-            "ranged": 80,
-            "lightning": 80,
-            "cold": 80,
-            "paralyse": 80,
-            "psychic": 80,
-            "holy": 80
-        },
-        "abilities": [
-            "bursting fire 50000",
-            "flying",
-            "regeneration"
-        ]
-    },
-    {
         "name": "Pikeman",
         "magic": "plain",
         "race": [
@@ -3206,7 +2835,6 @@
             "holy": 25
         },
         "abilities": [
-            "racial enemy against treefolk 50%",
             "scales",
             "weakness to attacktype cold"
         ]
@@ -3468,7 +3096,7 @@
         "counter": 600,
         "a2_power": 2300,
         "a2_type": "holy",
-        "a2_init": 2,
+        "a2_init": 3,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
@@ -3491,11 +3119,9 @@
             "holy": 0
         },
         "abilities": [
-            "racial enemy against demon 50%",
             "beauty",
             "charm",
-            "endurance",
-            "healing"
+            "endurance"
         ]
     },
     {
@@ -3624,7 +3250,7 @@
         "name": "Stone Golem",
         "magic": "plain",
         "race": [
-            "human"
+            "golem"
         ],
         "power": 1984,
         "hp": 15000,
@@ -3659,48 +3285,6 @@
         "abilities": [
             "clumsiness",
             "endurance",
-            "siege"
-        ]
-    },
-    {
-        "name": "Storm Giant",
-        "magic": "eradication",
-        "race": [
-            "giant"
-        ],
-        "power": 1550,
-        "hp": 5800,
-        "a1_power": 16000,
-        "a1_type": "lightning breath",
-        "a1_init": 3,
-        "counter": 300,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 40,
-            "nether": 0,
-            "phantasm": 75
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 70,
-            "poison": 30,
-            "breath": 80,
-            "magic": 0,
-            "melee": 75,
-            "ranged": 70,
-            "lightning": 100,
-            "cold": 85,
-            "paralyse": 45,
-            "psychic": 50,
-            "holy": 70
-        },
-        "abilities": [
-            "endurance",
-            "marksmanship",
             "siege"
         ]
     },
@@ -3835,49 +3419,6 @@
         ]
     },
     {
-        "name": "Titan",
-        "magic": "ascendant",
-        "race": [
-            "giant"
-        ],
-        "power": 50000,
-        "hp": 85000,
-        "a1_power": 200000,
-        "a1_type": "melee holy",
-        "a1_init": 1,
-        "counter": 50000,
-        "a2_power": 250000,
-        "a2_type": "ranged lightning",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 85,
-            "eradication": 85,
-            "nether": 85,
-            "phantasm": 85
-        },
-        "resistances": {
-            "missile": 85,
-            "fire": 75,
-            "poison": 85,
-            "breath": 80,
-            "magic": 80,
-            "melee": 90,
-            "ranged": 95,
-            "lightning": 100,
-            "cold": 85,
-            "paralyse": 85,
-            "psychic": 95,
-            "holy": 75
-        },
-        "abilities": [
-            "additional strike",
-            "endurance",
-            "marksmanship",
-            "siege"
-        ]
-    },
-    {
         "name": "Trained Elephant",
         "magic": "plain",
         "race": [
@@ -3951,12 +3492,53 @@
             "cold": 80,
             "paralyse": 75,
             "psychic": 75,
-            "holy": 50
+            "holy": 30
         },
         "abilities": [
             "additional strike",
             "endurance",
             "weakness to attacktype fire"
+        ]
+    },
+    {
+        "name": "Troglodyte",
+        "magic": "eradication",
+        "race": [
+            "reptile"
+        ],
+        "power": 22,
+        "hp": 160,
+        "a1_power": 200,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 35,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "recruit speed 35%",
+            "scales"
         ]
     },
     {
@@ -3997,7 +3579,6 @@
         },
         "abilities": [
             "additional strike",
-            "racial enemy against elemental 50%",
             "endurance",
             "fear",
             "marksmanship"
@@ -4050,7 +3631,7 @@
         "race": [
             "undead"
         ],
-        "power": 1858,
+        "power": 2058,
         "hp": 4500,
         "a1_power": 9000,
         "a1_type": "magic paralyse",
@@ -4149,7 +3730,7 @@
             "ascendant": 0,
             "verdant": 40,
             "eradication": 0,
-            "nether": 0,
+            "nether": 40,
             "phantasm": 40
         },
         "resistances": {
@@ -4213,46 +3794,6 @@
         ]
     },
     {
-        "name": "Water Elemental",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 19406,
-        "hp": 72000,
-        "a1_power": 400000,
-        "a1_type": "poison ranged",
-        "a1_init": 2,
-        "counter": 5000,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 100,
-            "fire": 50,
-            "poison": 100,
-            "breath": 0,
-            "magic": 50,
-            "melee": 100,
-            "ranged": 75,
-            "lightning": 100,
-            "cold": 25,
-            "paralyse": 100,
-            "psychic": 50,
-            "holy": 80
-        },
-        "abilities": [
-            "endurance"
-        ]
-    },
-    {
         "name": "Werebear",
         "magic": "verdant",
         "race": [
@@ -4260,7 +3801,7 @@
             "animal"
         ],
         "power": 161,
-        "hp": 1000,
+        "hp": 1500,
         "a1_power": 2300,
         "a1_type": "melee",
         "a1_init": 1,
@@ -4384,7 +3925,7 @@
         "race": [
             "undead"
         ],
-        "power": 130,
+        "power": 160,
         "hp": 1000,
         "a1_power": 2400,
         "a1_type": "magic paralyse",
@@ -4426,7 +3967,7 @@
         "race": [
             "dragon"
         ],
-        "power": 150,
+        "power": 190,
         "hp": 1000,
         "a1_power": 800,
         "a1_type": "melee poison",

--- a/data/blitz/units.json
+++ b/data/blitz/units.json
@@ -1,123 +1,127 @@
 [
     {
-        "name": "Militia",
-        "magic": "plain",
+        "name": "Air Elemental",
+        "magic": "phantasm",
         "race": [
-            "human"
+            "elemental"
         ],
-        "power": 9,
-        "hp": 80,
-        "a1_power": 80,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 20,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
+        "power": 25000,
+        "hp": 60000,
+        "a1_power": 300000,
+        "a1_type": "lightning ranged",
+        "a1_init": 4,
+        "counter": 6500,
+        "a2_power": 200000,
+        "a2_type": "magic",
+        "a2_init": 1,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
+            "eradication": 80,
+            "nether": 75,
+            "phantasm": 35
         },
         "resistances": {
-            "missile": 0,
-            "fire": 0,
+            "missile": 95,
+            "fire": 50,
             "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
+            "breath": 70,
+            "magic": 55,
+            "melee": 95,
+            "ranged": 95,
+            "lightning": 100,
             "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
+            "paralyse": 20,
+            "psychic": 50,
+            "holy": 80
         },
         "abilities": [
-            "clumsiness",
-            "recruit speed 100%"
+            "flying",
+            "swift"
         ]
     },
     {
-        "name": "Phalanx",
-        "magic": "plain",
+        "name": "Angel",
+        "magic": "ascendant",
         "race": [
-            "human"
+            "angel"
         ],
-        "power": 14,
-        "hp": 100,
-        "a1_power": 90,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 30,
+        "power": 193,
+        "hp": 1000,
+        "a1_power": 800,
+        "a1_type": "holy",
+        "a1_init": 2,
+        "counter": 200,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
+            "eradication": 25,
+            "nether": 65,
+            "phantasm": 15
         },
         "resistances": {
-            "missile": 0,
-            "fire": 0,
+            "missile": 50,
+            "fire": 50,
             "poison": 0,
             "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 50,
+            "cold": 50,
             "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
+            "psychic": 50,
+            "holy": 25
         },
         "abilities": [
-            "large shield"
+            "beauty",
+            "flying",
+            "healing"
         ]
     },
     {
-        "name": "Pikeman",
-        "magic": "plain",
+        "name": "Archangel",
+        "magic": "ascendant",
         "race": [
-            "human"
+            "angel"
         ],
-        "power": 12,
-        "hp": 90,
-        "a1_power": 100,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 40,
+        "power": 750,
+        "hp": 5000,
+        "a1_power": 4000,
+        "a1_type": "holy",
+        "a1_init": 2,
+        "counter": 400,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
+            "eradication": 45,
+            "nether": 70,
+            "phantasm": 30
         },
         "resistances": {
-            "missile": 0,
-            "fire": 0,
+            "missile": 70,
+            "fire": 70,
             "poison": 0,
             "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
+            "magic": 70,
+            "melee": 70,
+            "ranged": 70,
+            "lightning": 70,
+            "cold": 70,
             "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
+            "psychic": 70,
+            "holy": 50
         },
         "abilities": [
-            "pike"
+            "beauty",
+            "flying",
+            "healing"
         ]
     },
     {
@@ -156,20 +160,144 @@
             "psychic": 0,
             "holy": 0
         },
-        "abilities": []
+        "abilities": [
+            "-"
+        ]
     },
     {
-        "name": "Cavalry",
+        "name": "Astral Magician",
+        "magic": "ascendant",
+        "race": [
+            "astral"
+        ],
+        "power": 170,
+        "hp": 750,
+        "a1_power": 1200,
+        "a1_type": "ranged magic",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 1200,
+        "a2_type": "ranged lightning",
+        "a2_init": 4,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 30,
+            "nether": 60,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 40,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 45,
+            "melee": 30,
+            "ranged": 40,
+            "lightning": 65,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 45,
+            "holy": 20
+        },
+        "abilities": [
+            "swift"
+        ]
+    },
+    {
+        "name": "Bounty Hunter",
         "magic": "plain",
         "race": [
             "human"
         ],
-        "power": 18,
-        "hp": 120,
-        "a1_power": 180,
+        "power": 46,
+        "hp": 250,
+        "a1_power": 200,
+        "a1_type": "missile ranged",
+        "a1_init": 1,
+        "counter": 50,
+        "a2_power": 300,
+        "a2_type": "missile ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 25,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "marksmanship"
+        ]
+    },
+    {
+        "name": "Bulwark Horror",
+        "magic": "nether",
+        "race": [
+            "demon"
+        ],
+        "power": 2018,
+        "hp": 10750,
+        "a1_power": 13600,
+        "a1_type": "melee poison",
+        "a1_init": 1,
+        "counter": 4900,
+        "a2_power": 9000,
+        "a2_type": "cold ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 75,
+            "eradication": 75,
+            "nether": 0,
+            "phantasm": 35
+        },
+        "resistances": {
+            "missile": 40,
+            "fire": 60,
+            "poison": 50,
+            "breath": 70,
+            "magic": 20,
+            "melee": 90,
+            "ranged": 40,
+            "lightning": 30,
+            "cold": 40,
+            "paralyse": 30,
+            "psychic": 30,
+            "holy": 50
+        },
+        "abilities": [
+            "endurance",
+            "large shield",
+            "pike"
+        ]
+    },
+    {
+        "name": "Capsule Monster",
+        "magic": "plain",
+        "race": [
+            "animal"
+        ],
+        "power": 21,
+        "hp": 1,
+        "a1_power": 500,
         "a1_type": "melee",
         "a1_init": 2,
-        "counter": 30,
+        "counter": 0,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
@@ -191,10 +319,12 @@
             "lightning": 0,
             "cold": 0,
             "paralyse": 0,
-            "psychic": 0,
+            "psychic": 100,
             "holy": 0
         },
-        "abilities": []
+        "abilities": [
+            "flying"
+        ]
     },
     {
         "name": "Catapult",
@@ -234,21 +364,21 @@
         },
         "abilities": [
             "siege",
-            "weak to attack type fire"
+            "weakness to attacktype fire"
         ]
     },
     {
-        "name": "Knight",
-        "magic": "ascendant",
+        "name": "Cavalry",
+        "magic": "plain",
         "race": [
             "human"
         ],
-        "power": 23,
-        "hp": 200,
-        "a1_power": 250,
+        "power": 18,
+        "hp": 120,
+        "a1_power": 180,
         "a1_type": "melee",
         "a1_init": 2,
-        "counter": 50,
+        "counter": 30,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
@@ -274,22 +404,21 @@
             "holy": 0
         },
         "abilities": [
-            "large shield",
-            "recruit speed -15%"
+            "-"
         ]
     },
     {
-        "name": "Paladin",
-        "magic": "ascendant",
+        "name": "Cave Troll",
+        "magic": "nether",
         "race": [
-            "human"
+            "troll"
         ],
-        "power": 32,
-        "hp": 240,
-        "a1_power": 360,
-        "a1_type": "melee holy",
-        "a1_init": 2,
-        "counter": 60,
+        "power": 49,
+        "hp": 400,
+        "a1_power": 400,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 100,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
@@ -297,7 +426,7 @@
             "ascendant": 0,
             "verdant": 0,
             "eradication": 0,
-            "nether": 25,
+            "nether": 0,
             "phantasm": 0
         },
         "resistances": {
@@ -306,7 +435,7 @@
             "poison": 0,
             "breath": 0,
             "magic": 0,
-            "melee": 33,
+            "melee": 0,
             "ranged": 0,
             "lightning": 0,
             "cold": 0,
@@ -315,8 +444,91 @@
             "holy": 0
         },
         "abilities": [
-            "large shield",
-            "recruit speed -15%"
+            "regeneration",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
+        "name": "Chimera",
+        "magic": "eradication",
+        "race": [
+            "dragon"
+        ],
+        "power": 391,
+        "hp": 2200,
+        "a1_power": 2500,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 300,
+        "a2_power": 5000,
+        "a2_type": "fire breath",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 50,
+            "poison": 33,
+            "breath": 33,
+            "magic": 15,
+            "melee": 50,
+            "ranged": 33,
+            "lightning": 15,
+            "cold": 0,
+            "paralyse": 33,
+            "psychic": 0,
+            "holy": 50
+        },
+        "abilities": [
+            "flying",
+            "scales"
+        ]
+    },
+    {
+        "name": "Creeping Vines",
+        "magic": "verdant",
+        "race": [
+            "treefolk"
+        ],
+        "power": 40,
+        "hp": 336,
+        "a1_power": 336,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 118,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "regeneration",
+            "steal life 5%",
+            "weakness to attacktype fire"
         ]
     },
     {
@@ -361,15 +573,303 @@
         ]
     },
     {
-        "name": "High Priest",
-        "magic": "ascendant",
+        "name": "Dark Apprentice",
+        "magic": "nether",
         "race": [
             "human"
         ],
-        "power": 21,
-        "hp": 130,
-        "a1_power": 200,
-        "a1_type": "ranged holy",
+        "power": 51,
+        "hp": 100,
+        "a1_power": 700,
+        "a1_type": "magic ranged",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 80,
+            "fire": 50,
+            "poison": 0,
+            "breath": 0,
+            "magic": 80,
+            "melee": 80,
+            "ranged": 80,
+            "lightning": 50,
+            "cold": 0,
+            "paralyse": 80,
+            "psychic": 80,
+            "holy": 0
+        },
+        "abilities": [
+            "marksmanship",
+            "recruit speed -10%",
+            "swift"
+        ]
+    },
+    {
+        "name": "Dark Elf Magician",
+        "magic": "nether",
+        "race": [
+            "elf"
+        ],
+        "power": 666,
+        "hp": 4500,
+        "a1_power": 4500,
+        "a1_type": "fire ranged",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 3000,
+        "a2_type": "ranged lightning",
+        "a2_init": 4,
+        "spell_resistance": {
+            "ascendant": 50,
+            "verdant": 80,
+            "eradication": 80,
+            "nether": 0,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 85,
+            "fire": 70,
+            "poison": 0,
+            "breath": 0,
+            "magic": 90,
+            "melee": 90,
+            "ranged": 75,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 40,
+            "psychic": 0,
+            "holy": 25
+        },
+        "abilities": [
+            "marksmanship"
+        ]
+    },
+    {
+        "name": "Demon Knight",
+        "magic": "nether",
+        "race": [
+            "demon"
+        ],
+        "power": 1850,
+        "hp": 8500,
+        "a1_power": 10000,
+        "a1_type": "cold melee",
+        "a1_init": 2,
+        "counter": 6000,
+        "a2_power": 8000,
+        "a2_type": "poison ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 25,
+            "eradication": 60,
+            "nether": 0,
+            "phantasm": 20
+        },
+        "resistances": {
+            "missile": 70,
+            "fire": 60,
+            "poison": 75,
+            "breath": 0,
+            "magic": 60,
+            "melee": 85,
+            "ranged": 70,
+            "lightning": 70,
+            "cold": 75,
+            "paralyse": 60,
+            "psychic": 50,
+            "holy": 30
+        },
+        "abilities": [
+            "additional strike",
+            "endurance",
+            "steal life 5%",
+            "swift"
+        ]
+    },
+    {
+        "name": "Devil",
+        "magic": "nether",
+        "race": [
+            "demon"
+        ],
+        "power": 18586,
+        "hp": 40000,
+        "a1_power": 100000,
+        "a1_type": "fire",
+        "a1_init": 1,
+        "counter": 14000,
+        "a2_power": 200000,
+        "a2_type": "magic ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 50,
+            "verdant": 50,
+            "eradication": 400,
+            "nether": 400,
+            "phantasm": 400
+        },
+        "resistances": {
+            "missile": 100,
+            "fire": 100,
+            "poison": 50,
+            "breath": 0,
+            "magic": 50,
+            "melee": 100,
+            "ranged": 100,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 50,
+            "holy": 0
+        },
+        "abilities": [
+            "endurance",
+            "flying"
+        ]
+    },
+    {
+        "name": "Djinni",
+        "magic": "phantasm",
+        "race": [
+            "elemental"
+        ],
+        "power": 1700,
+        "hp": 7650,
+        "a1_power": 8000,
+        "a1_type": "magic",
+        "a1_init": 2,
+        "counter": 1200,
+        "a2_power": 12000,
+        "a2_type": "lightning ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 65,
+            "phantasm": 20
+        },
+        "resistances": {
+            "missile": 80,
+            "fire": 60,
+            "poison": 0,
+            "breath": 60,
+            "magic": 50,
+            "melee": 80,
+            "ranged": 95,
+            "lightning": 90,
+            "cold": 50,
+            "paralyse": 40,
+            "psychic": 50,
+            "holy": 50
+        },
+        "abilities": [
+            "flying",
+            "marksmanship"
+        ]
+    },
+    {
+        "name": "Dominion",
+        "magic": "ascendant",
+        "race": [
+            "angel"
+        ],
+        "power": 39013,
+        "hp": 80000,
+        "a1_power": 200000,
+        "a1_type": "holy",
+        "a1_init": 2,
+        "counter": 30000,
+        "a2_power": 250000,
+        "a2_type": "holy",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 80,
+            "nether": 80,
+            "phantasm": 50
+        },
+        "resistances": {
+            "missile": 85,
+            "fire": 85,
+            "poison": 85,
+            "breath": 85,
+            "magic": 85,
+            "melee": 85,
+            "ranged": 85,
+            "lightning": 85,
+            "cold": 85,
+            "paralyse": 85,
+            "psychic": 85,
+            "holy": 80
+        },
+        "abilities": [
+            "flying",
+            "healing"
+        ]
+    },
+    {
+        "name": "Druid",
+        "magic": "verdant",
+        "race": [
+            "elf"
+        ],
+        "power": 40,
+        "hp": 180,
+        "a1_power": 440,
+        "a1_type": "magic ranged",
+        "a1_init": 3,
+        "counter": 60,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 25,
+            "poison": 90,
+            "breath": 0,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 25,
+            "cold": 25,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 25
+        },
+        "abilities": [
+            "recruit speed -15%"
+        ]
+    },
+    {
+        "name": "Dryad",
+        "magic": "verdant",
+        "race": [
+            "pixie"
+        ],
+        "power": 23,
+        "hp": 70,
+        "a1_power": 240,
+        "a1_type": "magic ranged",
         "a1_init": 3,
         "counter": 0,
         "a2_power": 0,
@@ -379,68 +879,272 @@
             "ascendant": 0,
             "verdant": 0,
             "eradication": 0,
-            "nether": 50,
+            "nether": 0,
             "phantasm": 0
         },
         "resistances": {
-            "missile": 50,
+            "missile": 30,
             "fire": 0,
-            "poison": 0,
+            "poison": 20,
             "breath": 0,
-            "magic": 25,
-            "melee": 50,
-            "ranged": 50,
+            "magic": 20,
+            "melee": 40,
+            "ranged": 0,
             "lightning": 0,
             "cold": 0,
-            "paralyse": 0,
-            "psychic": 50,
-            "holy": 25
+            "paralyse": 30,
+            "psychic": 40,
+            "holy": 0
         },
         "abilities": [
-            "healing",
-            "recruit speed -10%"
+            "beauty",
+            "charm"
         ]
     },
     {
-        "name": "Knight Templar",
-        "magic": "ascendant",
+        "name": "Dwarven Deathseeker",
+        "magic": "eradication",
         "race": [
-            "human"
+            "dwarf"
         ],
-        "power": 60,
-        "hp": 375,
-        "a1_power": 400,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 75,
-        "a2_power": 150,
-        "a2_type": "ranged holy",
-        "a2_init": 3,
+        "power": 40,
+        "hp": 250,
+        "a1_power": 275,
+        "a1_type": "poison melee",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
             "eradication": 0,
-            "nether": 50,
+            "nether": 0,
             "phantasm": 0
         },
         "resistances": {
-            "missile": 25,
+            "missile": 0,
             "fire": 0,
-            "poison": 0,
+            "poison": 80,
             "breath": 0,
-            "magic": 25,
-            "melee": 75,
-            "ranged": 25,
+            "magic": 0,
+            "melee": 30,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 30,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "bursting poison 30"
+        ]
+    },
+    {
+        "name": "Dwarven Elite",
+        "magic": "eradication",
+        "race": [
+            "dwarf"
+        ],
+        "power": 27,
+        "hp": 220,
+        "a1_power": 300,
+        "a1_type": "melee poison",
+        "a1_init": 1,
+        "counter": 70,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 50,
+            "breath": 0,
+            "magic": 30,
+            "melee": 33,
+            "ranged": 30,
             "lightning": 0,
             "cold": 0,
             "paralyse": 0,
-            "psychic": 50,
-            "holy": 25
+            "psychic": 0,
+            "holy": 15
         },
         "abilities": [
-            "healing",
-            "large shield",
-            "recruit speed -8%"
+            "racial enemy against orc 50%",
+            "endurance",
+            "recruit speed 10%"
+        ]
+    },
+    {
+        "name": "Dwarven Shaman",
+        "magic": "eradication",
+        "race": [
+            "dwarf"
+        ],
+        "power": 1000,
+        "hp": 4500,
+        "a1_power": 5000,
+        "a1_type": "fire",
+        "a1_init": 2,
+        "counter": 300,
+        "a2_power": 8000,
+        "a2_type": "lightning",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 50,
+            "eradication": 50,
+            "nether": 10,
+            "phantasm": 10
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 70,
+            "poison": 30,
+            "breath": 65,
+            "magic": 100,
+            "melee": 85,
+            "ranged": 75,
+            "lightning": 0,
+            "cold": 85,
+            "paralyse": 45,
+            "psychic": 0,
+            "holy": 90
+        },
+        "abilities": [
+            "healing"
+        ]
+    },
+    {
+        "name": "Dwarven Warrior",
+        "magic": "eradication",
+        "race": [
+            "dwarf"
+        ],
+        "power": 20,
+        "hp": 160,
+        "a1_power": 200,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 25,
+            "breath": 0,
+            "magic": 15,
+            "melee": 25,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 10
+        },
+        "abilities": [
+            "racial enemy against orc 50%",
+            "endurance",
+            "recruit speed 30%"
+        ]
+    },
+    {
+        "name": "Earth Elemental",
+        "magic": "verdant",
+        "race": [
+            "elemental"
+        ],
+        "power": 22000,
+        "hp": 100000,
+        "a1_power": 100000,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 15000,
+        "a2_power": 550000,
+        "a2_type": "magic ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 40,
+            "eradication": 50,
+            "nether": 60,
+            "phantasm": 40
+        },
+        "resistances": {
+            "missile": 90,
+            "fire": 50,
+            "poison": 100,
+            "breath": 60,
+            "magic": 50,
+            "melee": 90,
+            "ranged": 70,
+            "lightning": 50,
+            "cold": 40,
+            "paralyse": 95,
+            "psychic": 80,
+            "holy": 80
+        },
+        "abilities": [
+            "endurance"
+        ]
+    },
+    {
+        "name": "Efreeti",
+        "magic": "eradication",
+        "race": [
+            "elemental"
+        ],
+        "power": 1200,
+        "hp": 3600,
+        "a1_power": 5000,
+        "a1_type": "fire ranged",
+        "a1_init": 4,
+        "counter": 800,
+        "a2_power": 8000,
+        "a2_type": "magic ranged",
+        "a2_init": 2,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 50,
+            "eradication": 50,
+            "nether": 65,
+            "phantasm": 20
+        },
+        "resistances": {
+            "missile": 40,
+            "fire": 30,
+            "poison": 55,
+            "breath": 0,
+            "magic": 50,
+            "melee": 60,
+            "ranged": 75,
+            "lightning": 75,
+            "cold": 75,
+            "paralyse": 45,
+            "psychic": 0,
+            "holy": 50
+        },
+        "abilities": [
+            "fear",
+            "marksmanship",
+            "swift"
         ]
     },
     {
@@ -486,6 +1190,51 @@
         ]
     },
     {
+        "name": "Elven Blade Dancer",
+        "magic": "verdant",
+        "race": [
+            "elf"
+        ],
+        "power": 1850,
+        "hp": 6500,
+        "a1_power": 9000,
+        "a1_type": "melee",
+        "a1_init": 4,
+        "counter": 1500,
+        "a2_power": 13500,
+        "a2_type": "paralyse ranged",
+        "a2_init": 1,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 80,
+            "eradication": 80,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 75,
+            "fire": 70,
+            "poison": 0,
+            "breath": 75,
+            "magic": 55,
+            "melee": 100,
+            "ranged": 75,
+            "lightning": 20,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 40,
+            "holy": 20
+        },
+        "abilities": [
+            "additional strike",
+            "racial enemy against angel 50%",
+            "beauty",
+            "bursting melee 3000",
+            "swift",
+            "weakness to attacktype cold"
+        ]
+    },
+    {
         "name": "Elven Magician",
         "magic": "verdant",
         "race": [
@@ -524,6 +1273,2515 @@
         "abilities": [
             "marksmanship",
             "recruit speed -10%",
+            "swift"
+        ]
+    },
+    {
+        "name": "Empyrean Inquisitor",
+        "magic": "ascendant",
+        "race": [
+            "astral"
+        ],
+        "power": 2500,
+        "hp": 9000,
+        "a1_power": 13500,
+        "a1_type": "magic",
+        "a1_init": 4,
+        "counter": 1900,
+        "a2_power": 2500,
+        "a2_type": "melee",
+        "a2_init": 1,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 75,
+            "eradication": 30,
+            "nether": 50,
+            "phantasm": 20
+        },
+        "resistances": {
+            "missile": 90,
+            "fire": 75,
+            "poison": 0,
+            "breath": 35,
+            "magic": 75,
+            "melee": 80,
+            "ranged": 80,
+            "lightning": 20,
+            "cold": 10,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 30
+        },
+        "abilities": [
+            "charm",
+            "fear"
+        ]
+    },
+    {
+        "name": "Faerie Dragon",
+        "magic": "verdant",
+        "race": [
+            "dragon"
+        ],
+        "power": 34,
+        "hp": 60,
+        "a1_power": 300,
+        "a1_type": "magic breath",
+        "a1_init": 5,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 400,
+            "nether": 400,
+            "phantasm": 400
+        },
+        "resistances": {
+            "missile": 90,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 90,
+            "melee": 90,
+            "ranged": 90,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 50
+        },
+        "abilities": [
+            "flying",
+            "recruit speed -30%",
+            "swift"
+        ]
+    },
+    {
+        "name": "Falcon",
+        "magic": "plain",
+        "race": [
+            "animal"
+        ],
+        "power": 15,
+        "hp": 50,
+        "a1_power": 200,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
+        "name": "Fallen Angel",
+        "magic": "nether",
+        "race": [
+            "angel"
+        ],
+        "power": 193,
+        "hp": 1500,
+        "a1_power": 2400,
+        "a1_type": "magic",
+        "a1_init": 2,
+        "counter": 400,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 50,
+            "verdant": 25,
+            "eradication": 25,
+            "nether": 50,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 50,
+            "poison": 25,
+            "breath": 25,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 55,
+            "cold": 50,
+            "paralyse": 25,
+            "psychic": 50,
+            "holy": 25
+        },
+        "abilities": [
+            "beauty",
+            "flying",
+            "healing"
+        ]
+    },
+    {
+        "name": "Fallen Archangel",
+        "magic": "nether",
+        "race": [
+            "angel"
+        ],
+        "power": 750,
+        "hp": 7500,
+        "a1_power": 12000,
+        "a1_type": "magic",
+        "a1_init": 2,
+        "counter": 800,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 70,
+            "verdant": 35,
+            "eradication": 35,
+            "nether": 70,
+            "phantasm": 35
+        },
+        "resistances": {
+            "missile": 75,
+            "fire": 75,
+            "poison": 25,
+            "breath": 25,
+            "magic": 75,
+            "melee": 75,
+            "ranged": 75,
+            "lightning": 80,
+            "cold": 75,
+            "paralyse": 25,
+            "psychic": 75,
+            "holy": 50
+        },
+        "abilities": [
+            "beauty",
+            "flying",
+            "healing"
+        ]
+    },
+    {
+        "name": "Fallen Dominion",
+        "magic": "nether",
+        "race": [
+            "angel"
+        ],
+        "power": 59020,
+        "hp": 120000,
+        "a1_power": 600000,
+        "a1_type": "magic",
+        "a1_init": 2,
+        "counter": 60000,
+        "a2_power": 800000,
+        "a2_type": "magic",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 80,
+            "verdant": 50,
+            "eradication": 80,
+            "nether": 80,
+            "phantasm": 50
+        },
+        "resistances": {
+            "missile": 85,
+            "fire": 85,
+            "poison": 85,
+            "breath": 85,
+            "magic": 85,
+            "melee": 85,
+            "ranged": 85,
+            "lightning": 90,
+            "cold": 85,
+            "paralyse": 85,
+            "psychic": 85,
+            "holy": 80
+        },
+        "abilities": [
+            "beauty",
+            "fear",
+            "flying",
+            "healing"
+        ]
+    },
+    {
+        "name": "Fanatic",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 12,
+        "hp": 500,
+        "a1_power": 500,
+        "a1_type": "holy",
+        "a1_init": 1,
+        "counter": 500,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 50,
+            "poison": 50,
+            "breath": 50,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 50,
+            "cold": 50,
+            "paralyse": 50,
+            "psychic": 50,
+            "holy": 50
+        },
+        "abilities": [
+            "additional strike"
+        ]
+    },
+    {
+        "name": "Fire Elemental",
+        "magic": "eradication",
+        "race": [
+            "elemental"
+        ],
+        "power": 21000,
+        "hp": 85000,
+        "a1_power": 100000,
+        "a1_type": "fire",
+        "a1_init": 1,
+        "counter": 9000,
+        "a2_power": 300000,
+        "a2_type": "fire ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 80,
+            "eradication": 80,
+            "nether": 80,
+            "phantasm": 40
+        },
+        "resistances": {
+            "missile": 100,
+            "fire": 100,
+            "poison": 95,
+            "breath": 100,
+            "magic": 50,
+            "melee": 85,
+            "ranged": 75,
+            "lightning": 60,
+            "cold": 20,
+            "paralyse": 100,
+            "psychic": 40,
+            "holy": 80
+        },
+        "abilities": [
+            "endurance",
+            "weakness to attacktype cold"
+        ]
+    },
+    {
+        "name": "Fire Giant",
+        "magic": "eradication",
+        "race": [
+            "giant"
+        ],
+        "power": 92,
+        "hp": 700,
+        "a1_power": 1100,
+        "a1_type": "fire ranged",
+        "a1_init": 3,
+        "counter": 200,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 100,
+            "poison": 0,
+            "breath": 25,
+            "magic": 25,
+            "melee": 25,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "endurance",
+            "recruit speed -25%",
+            "weakness to attacktype cold"
+        ]
+    },
+    {
+        "name": "Frog",
+        "magic": "plain",
+        "race": [
+            "animal"
+        ],
+        "power": 1,
+        "hp": 10,
+        "a1_power": 10,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "-"
+        ]
+    },
+    {
+        "name": "Gargoyle",
+        "magic": "nether",
+        "race": [
+            "golem"
+        ],
+        "power": 64,
+        "hp": 300,
+        "a1_power": 400,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 25,
+            "melee": 25,
+            "ranged": 25,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
+        "name": "Ghoul",
+        "magic": "nether",
+        "race": [
+            "undead"
+        ],
+        "power": 35,
+        "hp": 400,
+        "a1_power": 500,
+        "a1_type": "melee paralyse",
+        "a1_init": 1,
+        "counter": 200,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 100,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "steal life 5%",
+            "weaken resistance to holy"
+        ]
+    },
+    {
+        "name": "Goblin",
+        "magic": "eradication",
+        "race": [
+            "orc"
+        ],
+        "power": 13,
+        "hp": 150,
+        "a1_power": 125,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 50,
+        "a2_power": 75,
+        "a2_type": "ranged missile",
+        "a2_init": 1,
+        "spell_resistance": {
+            "ascendant": 25,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 50,
+            "poison": 0,
+            "breath": 25,
+            "magic": 0,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "racial enemy against human 100%",
+            "clumsiness",
+            "weaken resistance to ranged"
+        ]
+    },
+    {
+        "name": "Gorilla",
+        "magic": "verdant",
+        "race": [
+            "animal"
+        ],
+        "power": 34,
+        "hp": 450,
+        "a1_power": 240,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 80,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "-"
+        ]
+    },
+    {
+        "name": "Griffon",
+        "magic": "verdant",
+        "race": [
+            "animal"
+        ],
+        "power": 399,
+        "hp": 3750,
+        "a1_power": 2750,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 500,
+        "a2_power": 3450,
+        "a2_type": "melee",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 20,
+            "nether": 50,
+            "phantasm": 40
+        },
+        "resistances": {
+            "missile": 60,
+            "fire": 30,
+            "poison": 40,
+            "breath": 30,
+            "magic": 20,
+            "melee": 50,
+            "ranged": 45,
+            "lightning": 0,
+            "cold": 30,
+            "paralyse": 0,
+            "psychic": 25,
+            "holy": 0
+        },
+        "abilities": [
+            "endurance",
+            "flying"
+        ]
+    },
+    {
+        "name": "Hell Hound",
+        "magic": "eradication",
+        "race": [
+            "demon"
+        ],
+        "power": 159,
+        "hp": 700,
+        "a1_power": 1000,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 300,
+        "a2_power": 1800,
+        "a2_type": "fire breath",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 100,
+            "poison": 50,
+            "breath": 0,
+            "magic": 25,
+            "melee": 35,
+            "ranged": 25,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 25,
+            "holy": 10
+        },
+        "abilities": [
+            "fear",
+            "weakness to attacktype cold"
+        ]
+    },
+    {
+        "name": "High Elf",
+        "magic": "verdant",
+        "race": [
+            "elf"
+        ],
+        "power": 1542,
+        "hp": 5000,
+        "a1_power": 13000,
+        "a1_type": "paralyse ranged",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 7500,
+        "a2_type": "lightning ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 75,
+            "nether": 50,
+            "phantasm": 40
+        },
+        "resistances": {
+            "missile": 70,
+            "fire": 70,
+            "poison": 20,
+            "breath": 50,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 70,
+            "lightning": 70,
+            "cold": 20,
+            "paralyse": 70,
+            "psychic": 50,
+            "holy": 40
+        },
+        "abilities": [
+            "beauty",
+            "swift"
+        ]
+    },
+    {
+        "name": "High Priest",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 21,
+        "hp": 130,
+        "a1_power": 200,
+        "a1_type": "ranged holy",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 50,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 25,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 50,
+            "holy": 25
+        },
+        "abilities": [
+            "healing",
+            "recruit speed -10%"
+        ]
+    },
+    {
+        "name": "Horned Demon",
+        "magic": "nether",
+        "race": [
+            "demon"
+        ],
+        "power": 170,
+        "hp": 950,
+        "a1_power": 2750,
+        "a1_type": "poison melee",
+        "a1_init": 1,
+        "counter": 450,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 50,
+            "poison": 75,
+            "breath": 0,
+            "magic": 25,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 20,
+            "psychic": 0,
+            "holy": 25
+        },
+        "abilities": [
+            "additional strike",
+            "swift"
+        ]
+    },
+    {
+        "name": "Hydra",
+        "magic": "eradication",
+        "race": [
+            "reptile"
+        ],
+        "power": 457,
+        "hp": 3000,
+        "a1_power": 3000,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 800,
+        "a2_power": 2500,
+        "a2_type": "poison breath",
+        "a2_init": 2,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 33,
+            "eradication": 50,
+            "nether": 0,
+            "phantasm": 80
+        },
+        "resistances": {
+            "missile": 80,
+            "fire": 50,
+            "poison": 45,
+            "breath": 0,
+            "magic": 45,
+            "melee": 80,
+            "ranged": 45,
+            "lightning": 45,
+            "cold": 0,
+            "paralyse": 45,
+            "psychic": 45,
+            "holy": 50
+        },
+        "abilities": [
+            "additional strike",
+            "endurance",
+            "regeneration",
+            "scales",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
+        "name": "Ice Elemental",
+        "magic": "phantasm",
+        "race": [
+            "elemental"
+        ],
+        "power": 21800,
+        "hp": 90000,
+        "a1_power": 200000,
+        "a1_type": "cold ranged",
+        "a1_init": 1,
+        "counter": 10000,
+        "a2_power": 300000,
+        "a2_type": "cold ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 80,
+            "nether": 75,
+            "phantasm": 35
+        },
+        "resistances": {
+            "missile": 85,
+            "fire": 0,
+            "poison": 100,
+            "breath": 0,
+            "magic": 75,
+            "melee": 85,
+            "ranged": 85,
+            "lightning": 80,
+            "cold": 100,
+            "paralyse": 100,
+            "psychic": 50,
+            "holy": 80
+        },
+        "abilities": [
+            "weakness to attacktype fire"
+        ]
+    },
+    {
+        "name": "Imp",
+        "magic": "nether",
+        "race": [
+            "demon"
+        ],
+        "power": 19,
+        "hp": 80,
+        "a1_power": 150,
+        "a1_type": "poison",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 30,
+            "fire": 0,
+            "poison": 30,
+            "breath": 0,
+            "magic": 30,
+            "melee": 30,
+            "ranged": 30,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 30,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
+        "name": "Knight",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 23,
+        "hp": 200,
+        "a1_power": 250,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed -15%"
+        ]
+    },
+    {
+        "name": "Knight Templar",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 60,
+        "hp": 375,
+        "a1_power": 400,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 75,
+        "a2_power": 150,
+        "a2_type": "ranged holy",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 50,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 25,
+            "melee": 75,
+            "ranged": 25,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 50,
+            "holy": 25
+        },
+        "abilities": [
+            "healing",
+            "large shield",
+            "recruit speed -8%"
+        ]
+    },
+    {
+        "name": "Leviathan",
+        "magic": "phantasm",
+        "race": [
+            "giant"
+        ],
+        "power": 49500,
+        "hp": 100000,
+        "a1_power": 200000,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 50000,
+        "a2_power": 300000,
+        "a2_type": "poison ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 50,
+            "verdant": 75,
+            "eradication": 75,
+            "nether": 90,
+            "phantasm": 80
+        },
+        "resistances": {
+            "missile": 95,
+            "fire": 50,
+            "poison": 100,
+            "breath": 80,
+            "magic": 90,
+            "melee": 95,
+            "ranged": 95,
+            "lightning": 70,
+            "cold": 80,
+            "paralyse": 90,
+            "psychic": 70,
+            "holy": 80
+        },
+        "abilities": [
+            "additional strike",
+            "endurance",
+            "marksmanship",
+            "scales"
+        ]
+    },
+    {
+        "name": "Lich",
+        "magic": "nether",
+        "race": [
+            "undead"
+        ],
+        "power": 2027,
+        "hp": 7500,
+        "a1_power": 5500,
+        "a1_type": "ranged cold",
+        "a1_init": 1,
+        "counter": 2000,
+        "a2_power": 16000,
+        "a2_type": "magic ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 65,
+            "nether": 65,
+            "phantasm": 40
+        },
+        "resistances": {
+            "missile": 95,
+            "fire": 75,
+            "poison": 50,
+            "breath": 25,
+            "magic": 75,
+            "melee": 95,
+            "ranged": 95,
+            "lightning": 50,
+            "cold": 75,
+            "paralyse": 75,
+            "psychic": 75,
+            "holy": 0
+        },
+        "abilities": [
+            "fear",
+            "weaken resistance to holy"
+        ]
+    },
+    {
+        "name": "Lizard Man",
+        "magic": "eradication",
+        "race": [
+            "reptile"
+        ],
+        "power": 36,
+        "hp": 250,
+        "a1_power": 300,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 60,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "scales"
+        ]
+    },
+    {
+        "name": "Mandrake",
+        "magic": "verdant",
+        "race": [
+            "treefolk"
+        ],
+        "power": 180,
+        "hp": 1344,
+        "a1_power": 1680,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 672,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 0,
+            "poison": 80,
+            "breath": 0,
+            "magic": 40,
+            "melee": 45,
+            "ranged": 35,
+            "lightning": 0,
+            "cold": 40,
+            "paralyse": 50,
+            "psychic": 0,
+            "holy": 25
+        },
+        "abilities": [
+            "additional strike",
+            "endurance",
+            "regeneration",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
+        "name": "Medusa",
+        "magic": "phantasm",
+        "race": [
+            "reptile"
+        ],
+        "power": 200,
+        "hp": 650,
+        "a1_power": 2000,
+        "a1_type": "paralyse",
+        "a1_init": 2,
+        "counter": 300,
+        "a2_power": 1000,
+        "a2_type": "poison ranged",
+        "a2_init": 1,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 30,
+            "nether": 40,
+            "phantasm": 30
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 60,
+            "breath": 0,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 50,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "fear",
+            "scales"
+        ]
+    },
+    {
+        "name": "Mercenary",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 68,
+        "hp": 300,
+        "a1_power": 600,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 300,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 33,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "additional strike",
+            "marksmanship"
+        ]
+    },
+    {
+        "name": "Militia",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 9,
+        "hp": 80,
+        "a1_power": 80,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 20,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "clumsiness",
+            "recruit speed 100%"
+        ]
+    },
+    {
+        "name": "Mind Ripper",
+        "magic": "phantasm",
+        "race": [
+            "telepath"
+        ],
+        "power": 1154,
+        "hp": 5000,
+        "a1_power": 8000,
+        "a1_type": "magic ranged",
+        "a1_init": 3,
+        "counter": 4000,
+        "a2_power": 16000,
+        "a2_type": "ranged psychic",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 75,
+            "eradication": 75,
+            "nether": 75,
+            "phantasm": 30
+        },
+        "resistances": {
+            "missile": 75,
+            "fire": 50,
+            "poison": 20,
+            "breath": 50,
+            "magic": 75,
+            "melee": 75,
+            "ranged": 75,
+            "lightning": 20,
+            "cold": 30,
+            "paralyse": 50,
+            "psychic": 90,
+            "holy": 50
+        },
+        "abilities": [
+            "-"
+        ]
+    },
+    {
+        "name": "Naga Queen",
+        "magic": "ascendant",
+        "race": [
+            "reptile"
+        ],
+        "power": 2700,
+        "hp": 10500,
+        "a1_power": 13000,
+        "a1_type": "melee lightning",
+        "a1_init": 2,
+        "counter": 2500,
+        "a2_power": 17600,
+        "a2_type": "lightning",
+        "a2_init": 2,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 85,
+            "eradication": 85,
+            "nether": 0,
+            "phantasm": 35
+        },
+        "resistances": {
+            "missile": 70,
+            "fire": 30,
+            "poison": 90,
+            "breath": 50,
+            "magic": 80,
+            "melee": 95,
+            "ranged": 70,
+            "lightning": 0,
+            "cold": 80,
+            "paralyse": 90,
+            "psychic": 90,
+            "holy": 30
+        },
+        "abilities": [
+            "marksmanship",
+            "scales"
+        ]
+    },
+    {
+        "name": "Nymph",
+        "magic": "verdant",
+        "race": [
+            "pixie"
+        ],
+        "power": 62,
+        "hp": 150,
+        "a1_power": 940,
+        "a1_type": "psychic ranged",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 40,
+            "holy": 25
+        },
+        "abilities": [
+            "beauty",
+            "charm"
+        ]
+    },
+    {
+        "name": "Ogre",
+        "magic": "eradication",
+        "race": [
+            "giant"
+        ],
+        "power": 34,
+        "hp": 300,
+        "a1_power": 400,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 100,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "endurance",
+            "recruit speed 10%"
+        ]
+    },
+    {
+        "name": "Orc Raider",
+        "magic": "nether",
+        "race": [
+            "orc"
+        ],
+        "power": 12,
+        "hp": 110,
+        "a1_power": 100,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 20,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "clumsiness",
+            "recruit speed 50%"
+        ]
+    },
+    {
+        "name": "Orcish Archer",
+        "magic": "nether",
+        "race": [
+            "orc"
+        ],
+        "power": 12,
+        "hp": 100,
+        "a1_power": 80,
+        "a1_type": "missile ranged",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "clumsiness",
+            "recruit speed 50%"
+        ]
+    },
+    {
+        "name": "Paladin",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 32,
+        "hp": 240,
+        "a1_power": 360,
+        "a1_type": "melee holy",
+        "a1_init": 2,
+        "counter": 60,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 25,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 33,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed -15%"
+        ]
+    },
+    {
+        "name": "Pegasus",
+        "magic": "ascendant",
+        "race": [
+            "animal"
+        ],
+        "power": 40,
+        "hp": 290,
+        "a1_power": 300,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
+        "name": "Phalanx",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 14,
+        "hp": 100,
+        "a1_power": 90,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 30,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield"
+        ]
+    },
+    {
+        "name": "Phantom",
+        "magic": "phantasm",
+        "race": [
+            "illusion"
+        ],
+        "power": 20,
+        "hp": 130,
+        "a1_power": 100,
+        "a1_type": "psychic ranged",
+        "a1_init": 1,
+        "counter": 350,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 75,
+            "breath": 0,
+            "magic": 0,
+            "melee": 100,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 100,
+            "holy": 50
+        },
+        "abilities": [
+            "fear",
+            "recruit speed -15%",
+            "weaken resistance to magic"
+        ]
+    },
+    {
+        "name": "Phoenix",
+        "magic": "verdant",
+        "race": [
+            "elemental"
+        ],
+        "power": 36883,
+        "hp": 70000,
+        "a1_power": 200000,
+        "a1_type": "magic",
+        "a1_init": 1,
+        "counter": 40000,
+        "a2_power": 600000,
+        "a2_type": "magic ranged",
+        "a2_init": 5,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 80,
+            "nether": 75,
+            "phantasm": 50
+        },
+        "resistances": {
+            "missile": 90,
+            "fire": 100,
+            "poison": 80,
+            "breath": 80,
+            "magic": 80,
+            "melee": 90,
+            "ranged": 80,
+            "lightning": 80,
+            "cold": 80,
+            "paralyse": 80,
+            "psychic": 80,
+            "holy": 80
+        },
+        "abilities": [
+            "bursting fire 50000",
+            "flying",
+            "regeneration"
+        ]
+    },
+    {
+        "name": "Pikeman",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 12,
+        "hp": 90,
+        "a1_power": 100,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 40,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "pike"
+        ]
+    },
+    {
+        "name": "Preacher",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 16,
+        "hp": 133,
+        "a1_power": 10,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 75,
+            "nether": 75,
+            "phantasm": 50
+        },
+        "resistances": {
+            "missile": 75,
+            "fire": 75,
+            "poison": 75,
+            "breath": 75,
+            "magic": 75,
+            "melee": 75,
+            "ranged": 75,
+            "lightning": 75,
+            "cold": 75,
+            "paralyse": 75,
+            "psychic": 100,
+            "holy": 75
+        },
+        "abilities": [
+            "healing"
+        ]
+    },
+    {
+        "name": "Psychic Wisp",
+        "magic": "phantasm",
+        "race": [
+            "elemental"
+        ],
+        "power": 40,
+        "hp": 100,
+        "a1_power": 460,
+        "a1_type": "ranged psychic",
+        "a1_init": 3,
+        "counter": 200,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 80,
+            "holy": 0
+        },
+        "abilities": [
+            "swift"
+        ]
+    },
+    {
+        "name": "Red Dragon",
+        "magic": "eradication",
+        "race": [
+            "dragon"
+        ],
+        "power": 82378,
+        "hp": 120000,
+        "a1_power": 250000,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 50000,
+        "a2_power": 500000,
+        "a2_type": "fire breath",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 90,
+            "verdant": 90,
+            "eradication": 90,
+            "nether": 90,
+            "phantasm": 90
+        },
+        "resistances": {
+            "missile": 90,
+            "fire": 100,
+            "poison": 90,
+            "breath": 60,
+            "magic": 91,
+            "melee": 95,
+            "ranged": 90,
+            "lightning": 60,
+            "cold": 30,
+            "paralyse": 90,
+            "psychic": 90,
+            "holy": 75
+        },
+        "abilities": [
+            "racial enemy against elf 50%",
+            "endurance",
+            "fear",
+            "flying",
+            "scales",
+            "weakness to attacktype cold"
+        ]
+    },
+    {
+        "name": "Renegade Wizard",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 72,
+        "hp": 100,
+        "a1_power": 1600,
+        "a1_type": "magic ranged",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 20
+        },
+        "resistances": {
+            "missile": 80,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 50,
+            "melee": 80,
+            "ranged": 80,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 80,
+            "holy": 30
+        },
+        "abilities": [
+            "-"
+        ]
+    },
+    {
+        "name": "Salamander",
+        "magic": "eradication",
+        "race": [
+            "elemental"
+        ],
+        "power": 188,
+        "hp": 1000,
+        "a1_power": 3000,
+        "a1_type": "fire",
+        "a1_init": 1,
+        "counter": 500,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 100,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 25
+        },
+        "abilities": [
+            "scales",
+            "weakness to attacktype cold"
+        ]
+    },
+    {
+        "name": "Shadow",
+        "magic": "nether",
+        "race": [
+            "undead"
+        ],
+        "power": 40,
+        "hp": 250,
+        "a1_power": 600,
+        "a1_type": "magic",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 100,
+            "fire": 0,
+            "poison": 40,
+            "breath": 0,
+            "magic": 0,
+            "melee": 100,
+            "ranged": 20,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 25,
+            "holy": 0
+        },
+        "abilities": [
+            "steal life 5%",
+            "weaken resistance to holy"
+        ]
+    },
+    {
+        "name": "Shadow Monster",
+        "magic": "phantasm",
+        "race": [
+            "illusion"
+        ],
+        "power": 6,
+        "hp": 1,
+        "a1_power": 400,
+        "a1_type": "psychic",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "-"
+        ]
+    },
+    {
+        "name": "Sheep",
+        "magic": "plain",
+        "race": [
+            "animal"
+        ],
+        "power": 1,
+        "hp": 10,
+        "a1_power": 10,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "-"
+        ]
+    },
+    {
+        "name": "Siren",
+        "magic": "phantasm",
+        "race": [
+            "pixie"
+        ],
+        "power": 176,
+        "hp": 600,
+        "a1_power": 3400,
+        "a1_type": "psychic",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 600,
+        "a2_type": "melee",
+        "a2_init": 1,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 25,
+            "melee": 33,
+            "ranged": 33,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 50,
+            "holy": 25
+        },
+        "abilities": [
+            "beauty",
+            "charm"
+        ]
+    },
+    {
+        "name": "Skeleton",
+        "magic": "nether",
+        "race": [
+            "undead"
+        ],
+        "power": 10,
+        "hp": 70,
+        "a1_power": 100,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 40,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 0,
+            "poison": 100,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "weaken resistance to holy"
+        ]
+    },
+    {
+        "name": "Soul Speaker",
+        "magic": "ascendant",
+        "race": [
+            "astral"
+        ],
+        "power": 27,
+        "hp": 75,
+        "a1_power": 260,
+        "a1_type": "ranged psychic",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 35,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 20,
+            "melee": 40,
+            "ranged": 0,
+            "lightning": 40,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 30,
+            "holy": 0
+        },
+        "abilities": [
+            "beauty",
+            "healing"
+        ]
+    },
+    {
+        "name": "Spirit Warrior",
+        "magic": "ascendant",
+        "race": [
+            "astral"
+        ],
+        "power": 475,
+        "hp": 2600,
+        "a1_power": 2900,
+        "a1_type": "melee holy",
+        "a1_init": 2,
+        "counter": 600,
+        "a2_power": 2300,
+        "a2_type": "holy",
+        "a2_init": 2,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 30,
+            "nether": 75,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 60,
+            "fire": 50,
+            "poison": 0,
+            "breath": 40,
+            "magic": 50,
+            "melee": 35,
+            "ranged": 25,
+            "lightning": 70,
+            "cold": 0,
+            "paralyse": 45,
+            "psychic": 40,
+            "holy": 0
+        },
+        "abilities": [
+            "beauty",
+            "charm",
+            "endurance"
+        ]
+    },
+    {
+        "name": "Sprite",
+        "magic": "phantasm",
+        "race": [
+            "pixie"
+        ],
+        "power": 38,
+        "hp": 75,
+        "a1_power": 400,
+        "a1_type": "magic",
+        "a1_init": 5,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 10
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "beauty",
+            "flying",
+            "swift"
+        ]
+    },
+    {
+        "name": "Squirrel",
+        "magic": "plain",
+        "race": [
+            "animal"
+        ],
+        "power": 1,
+        "hp": 10,
+        "a1_power": 10,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
+        "name": "Starving Peasant",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 2,
+        "hp": 20,
+        "a1_power": 50,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "clumsiness"
+        ]
+    },
+    {
+        "name": "Stone Golem",
+        "magic": "plain",
+        "race": [
+            "golem"
+        ],
+        "power": 1984,
+        "hp": 15000,
+        "a1_power": 20000,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 20000,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 75,
+            "verdant": 75,
+            "eradication": 75,
+            "nether": 75,
+            "phantasm": 75
+        },
+        "resistances": {
+            "missile": 99,
+            "fire": 50,
+            "poison": 100,
+            "breath": 0,
+            "magic": 50,
+            "melee": 99,
+            "ranged": 99,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 100,
+            "holy": 100
+        },
+        "abilities": [
+            "clumsiness",
+            "endurance",
+            "siege"
+        ]
+    },
+    {
+        "name": "Storm Giant",
+        "magic": "eradication",
+        "race": [
+            "giant"
+        ],
+        "power": 1550,
+        "hp": 5800,
+        "a1_power": 16000,
+        "a1_type": "lightning breath",
+        "a1_init": 3,
+        "counter": 300,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 75,
+            "eradication": 40,
+            "nether": 0,
+            "phantasm": 50
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 70,
+            "poison": 30,
+            "breath": 80,
+            "magic": 0,
+            "melee": 75,
+            "ranged": 70,
+            "lightning": 100,
+            "cold": 85,
+            "paralyse": 45,
+            "psychic": 50,
+            "holy": 70
+        },
+        "abilities": [
+            "endurance",
+            "marksmanship",
+            "siege"
+        ]
+    },
+    {
+        "name": "Succubus",
+        "magic": "nether",
+        "race": [
+            "demon"
+        ],
+        "power": 29,
+        "hp": 50,
+        "a1_power": 200,
+        "a1_type": "psychic",
+        "a1_init": 3,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 80,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "beauty",
+            "charm",
+            "endurance",
+            "flying",
             "swift"
         ]
     },
@@ -572,837 +3830,15 @@
         ]
     },
     {
-        "name": "Faerie Dragon",
-        "magic": "verdant",
-        "race": [
-            "dragon"
-        ],
-        "power": 34,
-        "hp": 60,
-        "a1_power": 300,
-        "a1_type": "magic breath",
-        "a1_init": 5,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 400,
-            "nether": 400,
-            "phantasm": 400
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 90,
-            "melee": 90,
-            "ranged": 90,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 50
-        },
-        "abilities": [
-            "flying",
-            "recruit speed -30%",
-            "swift"
-        ]
-    },
-    {
-        "name": "Druid",
-        "magic": "verdant",
-        "race": [
-            "elf"
-        ],
-        "power": 40,
-        "hp": 180,
-        "a1_power": 440,
-        "a1_type": "magic ranged",
-        "a1_init": 3,
-        "counter": 60,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 50,
-            "phantasm": 25
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 25,
-            "poison": 90,
-            "breath": 0,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 25,
-            "cold": 25,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 25
-        },
-        "abilities": [
-            "recruit speed -15%"
-        ]
-    },
-    {
-        "name": "Dwarven Warrior",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 20,
-        "hp": 160,
-        "a1_power": 200,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 50,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 25,
-            "breath": 0,
-            "magic": 15,
-            "melee": 25,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 10
-        },
-        "abilities": [
-            "endurance",
-            "recruit speed 30%",
-            "racial enemy orc 50%"
-        ]
-    },
-    {
-        "name": "Dwarven Elite",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 27,
-        "hp": 220,
-        "a1_power": 300,
-        "a1_type": "melee poison",
-        "a1_init": 1,
-        "counter": 70,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 50,
-            "breath": 0,
-            "magic": 30,
-            "melee": 33,
-            "ranged": 30,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 15
-        },
-        "abilities": [
-            "endurance",
-            "recruit speed 10%",
-            "racial enemy orc 50%"
-        ]
-    },
-    {
-        "name": "Fire Giant",
-        "magic": "eradication",
-        "race": [
-            "giant"
-        ],
-        "power": 92,
-        "hp": 700,
-        "a1_power": 1100,
-        "a1_type": "fire ranged",
-        "a1_init": 3,
-        "counter": 200,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 25,
-            "fire": 100,
-            "poison": 0,
-            "breath": 25,
-            "magic": 25,
-            "melee": 25,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "endurance",
-            "recruit speed -25%",
-            "weak to attack type cold"
-        ]
-    },
-    {
-        "name": "Ogre",
-        "magic": "eradication",
-        "race": [
-            "giant"
-        ],
-        "power": 34,
-        "hp": 300,
-        "a1_power": 400,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 100,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "endurance",
-            "recruit speed 10%"
-        ]
-    },
-    {
-        "name": "Troglodyte",
-        "magic": "eradication",
-        "race": [
-            "reptile"
-        ],
-        "power": 22,
-        "hp": 160,
-        "a1_power": 200,
-        "a1_type": "poison",
-        "a1_init": 1,
-        "counter": 35,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "recruit speed 35%",
-            "scales"
-        ]
-    },
-    {
-        "name": "Orc Raider",
-        "magic": "nether",
-        "race": [
-            "orc"
-        ],
-        "power": 12,
-        "hp": 110,
-        "a1_power": 100,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 20,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "clumsiness",
-            "recruit speed 50%"
-        ]
-    },
-    {
-        "name": "Wolf Raider",
-        "magic": "nether",
-        "race": [
-            "orc"
-        ],
-        "power": 25,
-        "hp": 550,
-        "a1_power": 200,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 150,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "clumsiness",
-            "recruit speed 33%"
-        ]
-    },
-    {
-        "name": "Orcish Archer",
-        "magic": "nether",
-        "race": [
-            "orc"
-        ],
-        "power": 12,
-        "hp": 100,
-        "a1_power": 80,
-        "a1_type": "missile ranged",
-        "a1_init": 3,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "clumsiness",
-            "recruit speed 50%"
-        ]
-    },
-    {
-        "name": "Cave Troll",
-        "magic": "nether",
-        "race": [
-            "troll"
-        ],
-        "power": 49,
-        "hp": 400,
-        "a1_power": 400,
-        "a1_type": "poison",
-        "a1_init": 1,
-        "counter": 100,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "regeneration",
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "Imp",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 19,
-        "hp": 80,
-        "a1_power": 150,
-        "a1_type": "poison",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 30,
-            "fire": 0,
-            "poison": 30,
-            "breath": 0,
-            "magic": 30,
-            "melee": 30,
-            "ranged": 30,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 30,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
-        "name": "Gargoyle",
-        "magic": "nether",
-        "race": [
-            "golem"
-        ],
-        "power": 64,
-        "hp": 300,
-        "a1_power": 400,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 25,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 25,
-            "melee": 25,
-            "ranged": 25,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 100,
-            "psychic": 100,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
-        "name": "Dark Apprentice",
-        "magic": "nether",
-        "race": [
-            "human"
-        ],
-        "power": 51,
-        "hp": 100,
-        "a1_power": 700,
-        "a1_type": "magic ranged",
-        "a1_init": 3,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 80,
-            "fire": 50,
-            "poison": 0,
-            "breath": 0,
-            "magic": 80,
-            "melee": 80,
-            "ranged": 80,
-            "lightning": 50,
-            "cold": 0,
-            "paralyse": 80,
-            "psychic": 80,
-            "holy": 0
-        },
-        "abilities": [
-            "marksmanship",
-            "recruit speed -10%",
-            "swift"
-        ]
-    },
-    {
-        "name": "Pegasus",
-        "magic": "ascendant",
-        "race": [
-            "animal"
-        ],
-        "power": 40,
-        "hp": 290,
-        "a1_power": 300,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
-        "name": "Angel",
-        "magic": "ascendant",
-        "race": [
-            "angel"
-        ],
-        "power": 193,
-        "hp": 1000,
-        "a1_power": 800,
-        "a1_type": "holy",
-        "a1_init": 2,
-        "counter": 200,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 65,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 50,
-            "poison": 0,
-            "breath": 0,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 50,
-            "cold": 50,
-            "paralyse": 0,
-            "psychic": 50,
-            "holy": 25
-        },
-        "abilities": [
-            "beauty",
-            "flying",
-            "healing"
-        ]
-    },
-    {
-        "name": "Unicorn",
-        "magic": "ascendant",
+        "name": "Sylph",
+        "magic": "phantasm",
         "race": [
             "elemental"
         ],
-        "power": 375,
-        "hp": 2500,
-        "a1_power": 4000,
+        "power": 68,
+        "hp": 150,
+        "a1_power": 1000,
         "a1_type": "magic",
-        "a1_init": 2,
-        "counter": 800,
-        "a2_power": 1000,
-        "a2_type": "melee",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 40,
-            "nether": 60,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 60,
-            "poison": 100,
-            "breath": 0,
-            "magic": 50,
-            "melee": 30,
-            "ranged": 30,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 60,
-            "psychic": 60,
-            "holy": 30
-        },
-        "abilities": [
-            "beauty",
-            "swift"
-        ]
-    },
-    {
-        "name": "Archangel",
-        "magic": "ascendant",
-        "race": [
-            "angel"
-        ],
-        "power": 750,
-        "hp": 5000,
-        "a1_power": 4000,
-        "a1_type": "holy",
-        "a1_init": 2,
-        "counter": 400,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 45,
-            "nether": 70,
-            "phantasm": 30
-        },
-        "resistances": {
-            "missile": 70,
-            "fire": 70,
-            "poison": 0,
-            "breath": 0,
-            "magic": 70,
-            "melee": 70,
-            "ranged": 70,
-            "lightning": 70,
-            "cold": 70,
-            "paralyse": 0,
-            "psychic": 70,
-            "holy": 50
-        },
-        "abilities": [
-            "beauty",
-            "flying",
-            "healing"
-        ]
-    },
-    {
-        "name": "Dominion",
-        "magic": "ascendant",
-        "race": [
-            "angel"
-        ],
-        "power": 39013,
-        "hp": 80000,
-        "a1_power": 200000,
-        "a1_type": "holy",
-        "a1_init": 2,
-        "counter": 30000,
-        "a2_power": 250000,
-        "a2_type": "holy",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 80,
-            "phantasm": 50
-        },
-        "resistances": {
-            "missile": 85,
-            "fire": 85,
-            "poison": 85,
-            "breath": 85,
-            "magic": 85,
-            "melee": 85,
-            "ranged": 85,
-            "lightning": 85,
-            "cold": 85,
-            "paralyse": 85,
-            "psychic": 85,
-            "holy": 80
-        },
-        "abilities": [
-            "flying",
-            "healing"
-        ]
-    },
-    {
-        "name": "Preacher",
-        "magic": "ascendant",
-        "race": [
-            "human"
-        ],
-        "power": 16,
-        "hp": 133,
-        "a1_power": 10,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 75,
-            "nether": 75,
-            "phantasm": 50
-        },
-        "resistances": {
-            "missile": 75,
-            "fire": 75,
-            "poison": 75,
-            "breath": 75,
-            "magic": 75,
-            "melee": 75,
-            "ranged": 75,
-            "lightning": 75,
-            "cold": 75,
-            "paralyse": 75,
-            "psychic": 100,
-            "holy": 75
-        },
-        "abilities": [
-            "healing"
-        ]
-    },
-    {
-        "name": "Soul Speaker",
-        "magic": "ascendant",
-        "race": [
-            "astral"
-        ],
-        "power": 27,
-        "hp": 75,
-        "a1_power": 260,
-        "a1_type": "ranged psychic",
         "a1_init": 3,
         "counter": 0,
         "a2_power": 0,
@@ -1411,109 +3847,28 @@
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 35,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 20,
-            "melee": 40,
-            "ranged": 0,
-            "lightning": 40,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 30,
-            "holy": 0
-        },
-        "abilities": [
-            "beauty",
-            "healing"
-        ]
-    },
-    {
-        "name": "Astral Magician",
-        "magic": "ascendant",
-        "race": [
-            "astral"
-        ],
-        "power": 170,
-        "hp": 750,
-        "a1_power": 1200,
-        "a1_type": "ranged magic",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 1200,
-        "a2_type": "ranged lightning",
-        "a2_init": 4,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 30,
-            "nether": 60,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 40,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 45,
-            "melee": 30,
-            "ranged": 40,
-            "lightning": 65,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 45,
-            "holy": 20
-        },
-        "abilities": [
-            "swift"
-        ]
-    },
-    {
-        "name": "Spirit Warrior",
-        "magic": "ascendant",
-        "race": [
-            "astral"
-        ],
-        "power": 475,
-        "hp": 2600,
-        "a1_power": 2900,
-        "a1_type": "melee holy",
-        "a1_init": 2,
-        "counter": 600,
-        "a2_power": 2300,
-        "a2_type": "holy",
-        "a2_init": 2,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 30,
-            "nether": 75,
+            "eradication": 33,
+            "nether": 33,
             "phantasm": 15
         },
         "resistances": {
-            "missile": 60,
-            "fire": 50,
+            "missile": 0,
+            "fire": 0,
             "poison": 0,
-            "breath": 40,
-            "magic": 50,
-            "melee": 35,
-            "ranged": 25,
-            "lightning": 70,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
             "cold": 0,
-            "paralyse": 45,
-            "psychic": 40,
+            "paralyse": 0,
+            "psychic": 0,
             "holy": 0
         },
         "abilities": [
             "beauty",
-            "charm",
-            "endurance"
+            "flying",
+            "swift"
         ]
     },
     {
@@ -1560,99 +3915,17 @@
         ]
     },
     {
-        "name": "Naga Queen",
-        "magic": "ascendant",
-        "race": [
-            "reptile"
-        ],
-        "power": 2700,
-        "hp": 10500,
-        "a1_power": 13000,
-        "a1_type": "melee lightning",
-        "a1_init": 2,
-        "counter": 2500,
-        "a2_power": 17600,
-        "a2_type": "lightning",
-        "a2_init": 2,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 85,
-            "eradication": 85,
-            "nether": 0,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 70,
-            "fire": 30,
-            "poison": 90,
-            "breath": 50,
-            "magic": 80,
-            "melee": 95,
-            "ranged": 70,
-            "lightning": 0,
-            "cold": 80,
-            "paralyse": 90,
-            "psychic": 90,
-            "holy": 30
-        },
-        "abilities": [
-            "marksmanship",
-            "scales"
-        ]
-    },
-    {
-        "name": "Empyrean Inquisitor",
-        "magic": "ascendant",
-        "race": [
-            "astral"
-        ],
-        "power": 2500,
-        "hp": 9000,
-        "a1_power": 13500,
-        "a1_type": "magic",
-        "a1_init": 4,
-        "counter": 1900,
-        "a2_power": 2500,
-        "a2_type": "melee",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 30,
-            "nether": 50,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 75,
-            "poison": 0,
-            "breath": 35,
-            "magic": 75,
-            "melee": 80,
-            "ranged": 80,
-            "lightning": 20,
-            "cold": 10,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 30
-        },
-        "abilities": [
-            "charm",
-            "fear"
-        ]
-    },
-    {
-        "name": "Gorilla",
-        "magic": "verdant",
+        "name": "Trained Elephant",
+        "magic": "plain",
         "race": [
             "animal"
         ],
-        "power": 34,
-        "hp": 450,
-        "a1_power": 240,
+        "power": 107,
+        "hp": 1000,
+        "a1_power": 1000,
         "a1_type": "melee",
         "a1_init": 1,
-        "counter": 80,
+        "counter": 200,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
@@ -1677,20 +3950,64 @@
             "psychic": 0,
             "holy": 0
         },
-        "abilities": []
+        "abilities": [
+            "clumsiness"
+        ]
     },
     {
-        "name": "Dryad",
+        "name": "Treant",
         "magic": "verdant",
         "race": [
-            "pixie"
+            "treefolk"
         ],
-        "power": 23,
-        "hp": 70,
-        "a1_power": 240,
-        "a1_type": "magic ranged",
-        "a1_init": 3,
-        "counter": 0,
+        "power": 423,
+        "hp": 4200,
+        "a1_power": 4200,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 1680,
+        "a2_power": 2500,
+        "a2_type": "melee",
+        "a2_init": 1,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 80
+        },
+        "resistances": {
+            "missile": 67,
+            "fire": 0,
+            "poison": 90,
+            "breath": 0,
+            "magic": 50,
+            "melee": 67,
+            "ranged": 67,
+            "lightning": 0,
+            "cold": 80,
+            "paralyse": 75,
+            "psychic": 75,
+            "holy": 50
+        },
+        "abilities": [
+            "additional strike",
+            "endurance",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
+        "name": "Troglodyte",
+        "magic": "eradication",
+        "race": [
+            "reptile"
+        ],
+        "power": 22,
+        "hp": 160,
+        "a1_power": 200,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 35,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
@@ -1702,63 +4019,314 @@
             "phantasm": 0
         },
         "resistances": {
-            "missile": 30,
+            "missile": 0,
             "fire": 0,
-            "poison": 20,
+            "poison": 0,
             "breath": 0,
-            "magic": 20,
-            "melee": 40,
+            "magic": 0,
+            "melee": 0,
             "ranged": 0,
             "lightning": 0,
             "cold": 0,
-            "paralyse": 30,
-            "psychic": 40,
+            "paralyse": 0,
+            "psychic": 0,
             "holy": 0
         },
         "abilities": [
-            "beauty",
-            "charm"
+            "recruit speed 35%",
+            "scales"
         ]
     },
     {
-        "name": "Nymph",
-        "magic": "verdant",
+        "name": "Unholy Reaver",
+        "magic": "nether",
         "race": [
-            "pixie"
+            "demon"
         ],
-        "power": 62,
-        "hp": 150,
-        "a1_power": 940,
-        "a1_type": "psychic ranged",
-        "a1_init": 3,
-        "counter": 0,
+        "power": 50000,
+        "hp": 85000,
+        "a1_power": 210000,
+        "a1_type": "melee paralyse",
+        "a1_init": 2,
+        "counter": 30000,
+        "a2_power": 470000,
+        "a2_type": "psychic ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 80,
+            "verdant": 0,
+            "eradication": 80,
+            "nether": 80,
+            "phantasm": 40
+        },
+        "resistances": {
+            "missile": 95,
+            "fire": 50,
+            "poison": 70,
+            "breath": 70,
+            "magic": 70,
+            "melee": 95,
+            "ranged": 75,
+            "lightning": 70,
+            "cold": 70,
+            "paralyse": 85,
+            "psychic": 85,
+            "holy": 30
+        },
+        "abilities": [
+            "additional strike",
+            "endurance",
+            "fear",
+            "marksmanship"
+        ]
+    },
+    {
+        "name": "Unicorn",
+        "magic": "ascendant",
+        "race": [
+            "elemental"
+        ],
+        "power": 375,
+        "hp": 2500,
+        "a1_power": 4000,
+        "a1_type": "magic",
+        "a1_init": 2,
+        "counter": 800,
+        "a2_power": 1000,
+        "a2_type": "melee",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 40,
+            "nether": 60,
+            "phantasm": 20
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 60,
+            "poison": 100,
+            "breath": 0,
+            "magic": 50,
+            "melee": 30,
+            "ranged": 30,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 60,
+            "psychic": 60,
+            "holy": 30
+        },
+        "abilities": [
+            "beauty",
+            "swift"
+        ]
+    },
+    {
+        "name": "Vampire",
+        "magic": "nether",
+        "race": [
+            "undead"
+        ],
+        "power": 2058,
+        "hp": 4500,
+        "a1_power": 9000,
+        "a1_type": "magic paralyse",
+        "a1_init": 2,
+        "counter": 2000,
+        "a2_power": 12000,
+        "a2_type": "magic ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 95,
+            "fire": 75,
+            "poison": 75,
+            "breath": 50,
+            "magic": 50,
+            "melee": 95,
+            "ranged": 95,
+            "lightning": 50,
+            "cold": 50,
+            "paralyse": 75,
+            "psychic": 75,
+            "holy": 0
+        },
+        "abilities": [
+            "charm",
+            "flying",
+            "marksmanship",
+            "steal life 5%",
+            "swift",
+            "weaken resistance to holy"
+        ]
+    },
+    {
+        "name": "Venomesse",
+        "magic": "plain",
+        "race": [
+            "human"
+        ],
+        "power": 45,
+        "hp": 200,
+        "a1_power": 500,
+        "a1_type": "poison",
+        "a1_init": 2,
+        "counter": 50,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 15
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
         },
         "resistances": {
-            "missile": 50,
+            "missile": 0,
             "fire": 0,
             "poison": 0,
             "breath": 0,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 50,
+            "magic": 0,
+            "melee": 33,
+            "ranged": 0,
             "lightning": 0,
             "cold": 0,
             "paralyse": 0,
-            "psychic": 40,
-            "holy": 25
+            "psychic": 0,
+            "holy": 0
         },
         "abilities": [
-            "beauty",
-            "charm"
+            "marksmanship",
+            "swift"
+        ]
+    },
+    {
+        "name": "Venus Flytrap",
+        "magic": "verdant",
+        "race": [
+            "treefolk"
+        ],
+        "power": 380,
+        "hp": 1344,
+        "a1_power": 1754,
+        "a1_type": "ranged poison",
+        "a1_init": 1,
+        "counter": 336,
+        "a2_power": 3000,
+        "a2_type": "ranged poison",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 40,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 40
+        },
+        "resistances": {
+            "missile": 67,
+            "fire": 0,
+            "poison": 90,
+            "breath": 20,
+            "magic": 50,
+            "melee": 67,
+            "ranged": 67,
+            "lightning": 40,
+            "cold": 40,
+            "paralyse": 75,
+            "psychic": 85,
+            "holy": 40
+        },
+        "abilities": [
+            "charm",
+            "regeneration",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
+        "name": "War Hound",
+        "magic": "plain",
+        "race": [
+            "animal"
+        ],
+        "power": 53,
+        "hp": 400,
+        "a1_power": 400,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 200,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "-"
+        ]
+    },
+    {
+        "name": "Water Elemental",
+        "magic": "phantasm",
+        "race": [
+            "elemental"
+        ],
+        "power": 19406,
+        "hp": 72000,
+        "a1_power": 400000,
+        "a1_type": "poison ranged",
+        "a1_init": 2,
+        "counter": 5000,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 80,
+            "nether": 75,
+            "phantasm": 35
+        },
+        "resistances": {
+            "missile": 100,
+            "fire": 50,
+            "poison": 100,
+            "breath": 0,
+            "magic": 50,
+            "melee": 100,
+            "ranged": 75,
+            "lightning": 100,
+            "cold": 25,
+            "paralyse": 100,
+            "psychic": 50,
+            "holy": 80
+        },
+        "abilities": [
+            "endurance"
         ]
     },
     {
@@ -1804,648 +4372,60 @@
         ]
     },
     {
-        "name": "Treant",
-        "magic": "verdant",
+        "name": "Werewolf",
+        "magic": "plain",
         "race": [
-            "treefolk"
+            "human",
+            "animal"
         ],
-        "power": 423,
-        "hp": 4200,
-        "a1_power": 4200,
+        "power": 190,
+        "hp": 1000,
+        "a1_power": 2300,
         "a1_type": "melee",
         "a1_init": 1,
-        "counter": 1680,
-        "a2_power": 2500,
+        "counter": 400,
+        "a2_power": 2300,
         "a2_type": "melee",
-        "a2_init": 1,
+        "a2_init": 2,
         "spell_resistance": {
             "ascendant": 0,
             "verdant": 0,
             "eradication": 0,
             "nether": 0,
-            "phantasm": 80
+            "phantasm": 0
         },
         "resistances": {
-            "missile": 67,
+            "missile": 50,
             "fire": 0,
-            "poison": 90,
+            "poison": 67,
             "breath": 0,
             "magic": 50,
-            "melee": 67,
-            "ranged": 67,
+            "melee": 50,
+            "ranged": 50,
             "lightning": 0,
-            "cold": 80,
-            "paralyse": 75,
-            "psychic": 75,
-            "holy": 50
+            "cold": 75,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 25
         },
         "abilities": [
             "additional strike",
             "endurance",
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "Phoenix",
-        "magic": "verdant",
-        "race": [
-            "elemental"
-        ],
-        "power": 36883,
-        "hp": 70000,
-        "a1_power": 200000,
-        "a1_type": "magic",
-        "a1_init": 1,
-        "counter": 40000,
-        "a2_power": 600000,
-        "a2_type": "magic ranged",
-        "a2_init": 5,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 50
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 100,
-            "poison": 80,
-            "breath": 80,
-            "magic": 80,
-            "melee": 90,
-            "ranged": 80,
-            "lightning": 80,
-            "cold": 80,
-            "paralyse": 80,
-            "psychic": 80,
-            "holy": 80
-        },
-        "abilities": [
-            "bursting fire 50000",
-            "flying",
             "regeneration"
         ]
     },
     {
-        "name": "Creeping Vines",
-        "magic": "verdant",
+        "name": "Wolf Raider",
+        "magic": "nether",
         "race": [
-            "treefolk"
+            "orc"
         ],
-        "power": 40,
-        "hp": 336,
-        "a1_power": 336,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 118,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "regeneration",
-            "steal life 5%",
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "Mandrake",
-        "magic": "verdant",
-        "race": [
-            "treefolk"
-        ],
-        "power": 180,
-        "hp": 1344,
-        "a1_power": 1680,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 672,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 0,
-            "poison": 80,
-            "breath": 0,
-            "magic": 40,
-            "melee": 45,
-            "ranged": 35,
-            "lightning": 0,
-            "cold": 40,
-            "paralyse": 50,
-            "psychic": 0,
-            "holy": 25
-        },
-        "abilities": [
-            "additional strike",
-            "endurance",
-            "regeneration",
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "Griffon",
-        "magic": "verdant",
-        "race": [
-            "animal"
-        ],
-        "power": 399,
-        "hp": 3750,
-        "a1_power": 2750,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 500,
-        "a2_power": 3450,
-        "a2_type": "melee",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 20,
-            "nether": 50,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 60,
-            "fire": 30,
-            "poison": 40,
-            "breath": 30,
-            "magic": 20,
-            "melee": 50,
-            "ranged": 45,
-            "lightning": 0,
-            "cold": 30,
-            "paralyse": 0,
-            "psychic": 25,
-            "holy": 0
-        },
-        "abilities": [
-            "endurance",
-            "flying"
-        ]
-    },
-    {
-        "name": "Earth Elemental",
-        "magic": "verdant",
-        "race": [
-            "elemental"
-        ],
-        "power": 22000,
-        "hp": 100000,
-        "a1_power": 100000,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 15000,
-        "a2_power": 550000,
-        "a2_type": "magic ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 40,
-            "eradication": 50,
-            "nether": 60,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 50,
-            "poison": 100,
-            "breath": 60,
-            "magic": 50,
-            "melee": 90,
-            "ranged": 70,
-            "lightning": 50,
-            "cold": 40,
-            "paralyse": 95,
-            "psychic": 80,
-            "holy": 80
-        },
-        "abilities": [
-            "endurance"
-        ]
-    },
-    {
-        "name": "Venus Flytrap",
-        "magic": "verdant",
-        "race": [
-            "treefolk"
-        ],
-        "power": 380,
-        "hp": 1344,
-        "a1_power": 1754,
-        "a1_type": "ranged poison",
-        "a1_init": 1,
-        "counter": 336,
-        "a2_power": 3000,
-        "a2_type": "ranged poison",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 40,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 67,
-            "fire": 0,
-            "poison": 90,
-            "breath": 20,
-            "magic": 50,
-            "melee": 67,
-            "ranged": 67,
-            "lightning": 40,
-            "cold": 40,
-            "paralyse": 75,
-            "psychic": 85,
-            "holy": 40
-        },
-        "abilities": [
-            "charm",
-            "regeneration",
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "High Elf",
-        "magic": "verdant",
-        "race": [
-            "elf"
-        ],
-        "power": 1542,
-        "hp": 5000,
-        "a1_power": 13000,
-        "a1_type": "paralyse ranged",
-        "a1_init": 3,
-        "counter": 0,
-        "a2_power": 7500,
-        "a2_type": "lightning ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 75,
-            "nether": 50,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 70,
-            "fire": 70,
-            "poison": 20,
-            "breath": 50,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 70,
-            "lightning": 70,
-            "cold": 20,
-            "paralyse": 70,
-            "psychic": 50,
-            "holy": 40
-        },
-        "abilities": [
-            "beauty",
-            "swift"
-        ]
-    },
-    {
-        "name": "Elven Blade Dancer",
-        "magic": "verdant",
-        "race": [
-            "elf"
-        ],
-        "power": 1850,
-        "hp": 6500,
-        "a1_power": 9000,
-        "a1_type": "melee",
-        "a1_init": 4,
-        "counter": 1500,
-        "a2_power": 13500,
-        "a2_type": "paralyse ranged",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 80,
-            "eradication": 80,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 75,
-            "fire": 70,
-            "poison": 0,
-            "breath": 75,
-            "magic": 55,
-            "melee": 100,
-            "ranged": 75,
-            "lightning": 20,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 40,
-            "holy": 20
-        },
-        "abilities": [
-            "additional strike",
-            "beauty",
-            "bursting melee 3000",
-            "swift",
-            "racial enemy angel 50%",
-            "weak to attack type cold"
-        ]
-    },
-    {
-        "name": "Lizard Man",
-        "magic": "eradication",
-        "race": [
-            "reptile"
-        ],
-        "power": 36,
-        "hp": 250,
-        "a1_power": 300,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 60,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "scales"
-        ]
-    },
-    {
-        "name": "Hell Hound",
-        "magic": "eradication",
-        "race": [
-            "demon"
-        ],
-        "power": 159,
-        "hp": 700,
-        "a1_power": 1000,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 300,
-        "a2_power": 1800,
-        "a2_type": "fire breath",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 25,
-            "fire": 100,
-            "poison": 50,
-            "breath": 0,
-            "magic": 25,
-            "melee": 35,
-            "ranged": 25,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 25,
-            "holy": 10
-        },
-        "abilities": [
-            "fear",
-            "weak to attack type cold"
-        ]
-    },
-    {
-        "name": "Salamander",
-        "magic": "eradication",
-        "race": [
-            "elemental"
-        ],
-        "power": 188,
-        "hp": 1000,
-        "a1_power": 3000,
-        "a1_type": "fire",
-        "a1_init": 1,
-        "counter": 500,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 25,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 100,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 25
-        },
-        "abilities": [
-            "scales",
-            "weak to attack type cold"
-        ]
-    },
-    {
-        "name": "Hydra",
-        "magic": "eradication",
-        "race": [
-            "reptile"
-        ],
-        "power": 457,
-        "hp": 3000,
-        "a1_power": 3000,
+        "power": 25,
+        "hp": 550,
+        "a1_power": 200,
         "a1_type": "melee",
         "a1_init": 2,
-        "counter": 800,
-        "a2_power": 2500,
-        "a2_type": "poison breath",
-        "a2_init": 2,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 33,
-            "eradication": 50,
-            "nether": 0,
-            "phantasm": 80
-        },
-        "resistances": {
-            "missile": 80,
-            "fire": 50,
-            "poison": 45,
-            "breath": 0,
-            "magic": 45,
-            "melee": 80,
-            "ranged": 45,
-            "lightning": 45,
-            "cold": 0,
-            "paralyse": 45,
-            "psychic": 45,
-            "holy": 50
-        },
-        "abilities": [
-            "additional strike",
-            "endurance",
-            "regeneration",
-            "scales",
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "Chimera",
-        "magic": "eradication",
-        "race": [
-            "dragon"
-        ],
-        "power": 391,
-        "hp": 2200,
-        "a1_power": 2500,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 300,
-        "a2_power": 5000,
-        "a2_type": "fire breath",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 50,
-            "poison": 33,
-            "breath": 33,
-            "magic": 15,
-            "melee": 50,
-            "ranged": 33,
-            "lightning": 15,
-            "cold": 0,
-            "paralyse": 33,
-            "psychic": 0,
-            "holy": 50
-        },
-        "abilities": [
-            "flying",
-            "scales"
-        ]
-    },
-    {
-        "name": "Red Dragon",
-        "magic": "eradication",
-        "race": [
-            "dragon"
-        ],
-        "power": 82378,
-        "hp": 120000,
-        "a1_power": 250000,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 50000,
-        "a2_power": 500000,
-        "a2_type": "fire breath",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 90,
-            "verdant": 90,
-            "eradication": 90,
-            "nether": 90,
-            "phantasm": 90
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 100,
-            "poison": 90,
-            "breath": 60,
-            "magic": 91,
-            "melee": 95,
-            "ranged": 90,
-            "lightning": 60,
-            "cold": 30,
-            "paralyse": 90,
-            "psychic": 90,
-            "holy": 75
-        },
-        "abilities": [
-            "endurance",
-            "fear",
-            "flying",
-            "scales",
-            "racial enemy elf 50%",
-            "undisbandable",
-            "weak to attack type cold"
-        ]
-    },
-    {
-        "name": "Dwarven Deathseeker",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 40,
-        "hp": 250,
-        "a1_power": 275,
-        "a1_type": "poison melee",
-        "a1_init": 1,
-        "counter": 0,
+        "counter": 150,
         "a2_power": 0,
         "a2_type": "",
         "a2_init": 0,
@@ -2459,19 +4439,62 @@
         "resistances": {
             "missile": 0,
             "fire": 0,
-            "poison": 80,
+            "poison": 0,
             "breath": 0,
             "magic": 0,
-            "melee": 30,
+            "melee": 0,
             "ranged": 0,
             "lightning": 0,
-            "cold": 30,
+            "cold": 0,
             "paralyse": 0,
             "psychic": 0,
             "holy": 0
         },
         "abilities": [
-            "bursting poison 30"
+            "clumsiness",
+            "recruit speed 33%"
+        ]
+    },
+    {
+        "name": "Wraith",
+        "magic": "nether",
+        "race": [
+            "undead"
+        ],
+        "power": 160,
+        "hp": 1000,
+        "a1_power": 2400,
+        "a1_type": "magic paralyse",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 40,
+            "fire": 0,
+            "poison": 50,
+            "breath": 0,
+            "magic": 20,
+            "melee": 60,
+            "ranged": 40,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 50,
+            "psychic": 50,
+            "holy": 0
+        },
+        "abilities": [
+            "flying",
+            "steal life 5%",
+            "weaken resistance to holy"
         ]
     },
     {
@@ -2517,250 +4540,45 @@
         ]
     },
     {
-        "name": "Efreeti",
-        "magic": "eradication",
-        "race": [
-            "elemental"
-        ],
-        "power": 1200,
-        "hp": 3600,
-        "a1_power": 5000,
-        "a1_type": "fire ranged",
-        "a1_init": 4,
-        "counter": 800,
-        "a2_power": 8000,
-        "a2_type": "magic ranged",
-        "a2_init": 2,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 50,
-            "eradication": 50,
-            "nether": 65,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 40,
-            "fire": 30,
-            "poison": 55,
-            "breath": 0,
-            "magic": 50,
-            "melee": 60,
-            "ranged": 75,
-            "lightning": 75,
-            "cold": 75,
-            "paralyse": 45,
-            "psychic": 0,
-            "holy": 50
-        },
-        "abilities": [
-            "fear",
-            "marksmanship",
-            "swift"
-        ]
-    },
-    {
-        "name": "Fire Elemental",
-        "magic": "eradication",
-        "race": [
-            "elemental"
-        ],
-        "power": 21000,
-        "hp": 85000,
-        "a1_power": 100000,
-        "a1_type": "fire",
-        "a1_init": 1,
-        "counter": 9000,
-        "a2_power": 300000,
-        "a2_type": "fire ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 80,
-            "eradication": 80,
-            "nether": 80,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 100,
-            "fire": 100,
-            "poison": 95,
-            "breath": 100,
-            "magic": 50,
-            "melee": 85,
-            "ranged": 75,
-            "lightning": 60,
-            "cold": 20,
-            "paralyse": 100,
-            "psychic": 40,
-            "holy": 80
-        },
-        "abilities": [
-            "endurance",
-            "weak to attack type cold"
-        ]
-    },
-    {
-        "name": "Dwarven Shaman",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 1000,
-        "hp": 4500,
-        "a1_power": 5000,
-        "a1_type": "fire",
-        "a1_init": 2,
-        "counter": 300,
-        "a2_power": 8000,
-        "a2_type": "lightning",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 50,
-            "eradication": 50,
-            "nether": 10,
-            "phantasm": 10
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 70,
-            "poison": 30,
-            "breath": 65,
-            "magic": 100,
-            "melee": 85,
-            "ranged": 75,
-            "lightning": 0,
-            "cold": 85,
-            "paralyse": 45,
-            "psychic": 0,
-            "holy": 90
-        },
-        "abilities": [
-            "healing"
-        ]
-    },
-    {
-        "name": "Storm Giant",
-        "magic": "eradication",
+        "name": "Yeti",
+        "magic": "phantasm",
         "race": [
             "giant"
         ],
-        "power": 1550,
-        "hp": 5800,
-        "a1_power": 16000,
-        "a1_type": "lightning breath",
-        "a1_init": 3,
-        "counter": 300,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
+        "power": 180,
+        "hp": 1000,
+        "a1_power": 500,
+        "a1_type": "cold",
+        "a1_init": 2,
+        "counter": 500,
+        "a2_power": 1400,
+        "a2_type": "breath cold",
+        "a2_init": 2,
         "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
+            "ascendant": 50,
+            "verdant": 0,
             "eradication": 40,
             "nether": 0,
-            "phantasm": 50
+            "phantasm": 80
         },
         "resistances": {
             "missile": 0,
-            "fire": 70,
-            "poison": 30,
-            "breath": 80,
-            "magic": 0,
-            "melee": 75,
-            "ranged": 70,
-            "lightning": 100,
-            "cold": 85,
-            "paralyse": 45,
-            "psychic": 50,
-            "holy": 70
-        },
-        "abilities": [
-            "endurance",
-            "marksmanship",
-            "siege"
-        ]
-    },
-    {
-        "name": "Goblin",
-        "magic": "eradication",
-        "race": [
-            "orc"
-        ],
-        "power": 13,
-        "hp": 150,
-        "a1_power": 125,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 50,
-        "a2_power": 75,
-        "a2_type": "ranged missile",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 25,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 25,
-            "fire": 50,
-            "poison": 0,
-            "breath": 25,
-            "magic": 0,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "clumsiness",
-            "racial enemy human 100%",
-            "weaken resistance to ranged"
-        ]
-    },
-    {
-        "name": "Skeleton",
-        "magic": "nether",
-        "race": [
-            "undead"
-        ],
-        "power": 10,
-        "hp": 70,
-        "a1_power": 100,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 40,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 50,
             "fire": 0,
-            "poison": 100,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 100,
-            "psychic": 100,
-            "holy": 0
+            "poison": 40,
+            "breath": 50,
+            "magic": 60,
+            "melee": 30,
+            "ranged": 65,
+            "lightning": 10,
+            "cold": 80,
+            "paralyse": 10,
+            "psychic": 0,
+            "holy": 85
         },
         "abilities": [
-            "weaken resistance to holy"
+            "marksmanship",
+            "swift",
+            "weakness to attacktype fire"
         ]
     },
     {
@@ -2802,1821 +4620,6 @@
         "abilities": [
             "clumsiness",
             "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Ghoul",
-        "magic": "nether",
-        "race": [
-            "undead"
-        ],
-        "power": 35,
-        "hp": 400,
-        "a1_power": 500,
-        "a1_type": "melee paralyse",
-        "a1_init": 1,
-        "counter": 200,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 100,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 100,
-            "psychic": 100,
-            "holy": 0
-        },
-        "abilities": [
-            "steal life 5%",
-            "undisbandable",
-            "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Wraith",
-        "magic": "nether",
-        "race": [
-            "undead"
-        ],
-        "power": 160,
-        "hp": 1000,
-        "a1_power": 2400,
-        "a1_type": "magic paralyse",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 40,
-            "fire": 0,
-            "poison": 50,
-            "breath": 0,
-            "magic": 20,
-            "melee": 60,
-            "ranged": 40,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 50,
-            "psychic": 50,
-            "holy": 0
-        },
-        "abilities": [
-            "flying",
-            "steal life 5%",
-            "undisbandable",
-            "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Vampire",
-        "magic": "nether",
-        "race": [
-            "undead"
-        ],
-        "power": 2058,
-        "hp": 4500,
-        "a1_power": 9000,
-        "a1_type": "magic paralyse",
-        "a1_init": 2,
-        "counter": 2000,
-        "a2_power": 12000,
-        "a2_type": "magic ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 50,
-            "phantasm": 25
-        },
-        "resistances": {
-            "missile": 95,
-            "fire": 75,
-            "poison": 75,
-            "breath": 50,
-            "magic": 50,
-            "melee": 95,
-            "ranged": 95,
-            "lightning": 50,
-            "cold": 50,
-            "paralyse": 75,
-            "psychic": 75,
-            "holy": 0
-        },
-        "abilities": [
-            "charm",
-            "flying",
-            "marksmanship",
-            "steal life 5%",
-            "swift",
-            "undisbandable",
-            "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Lich",
-        "magic": "nether",
-        "race": [
-            "undead"
-        ],
-        "power": 2027,
-        "hp": 7500,
-        "a1_power": 5500,
-        "a1_type": "ranged cold",
-        "a1_init": 1,
-        "counter": 2000,
-        "a2_power": 16000,
-        "a2_type": "magic ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 65,
-            "nether": 65,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 95,
-            "fire": 75,
-            "poison": 50,
-            "breath": 25,
-            "magic": 75,
-            "melee": 95,
-            "ranged": 95,
-            "lightning": 50,
-            "cold": 75,
-            "paralyse": 75,
-            "psychic": 75,
-            "holy": 0
-        },
-        "abilities": [
-            "fear",
-            "undisbandable",
-            "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Devil",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 18586,
-        "hp": 40000,
-        "a1_power": 100000,
-        "a1_type": "fire",
-        "a1_init": 1,
-        "counter": 14000,
-        "a2_power": 200000,
-        "a2_type": "magic ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 50,
-            "eradication": 400,
-            "nether": 400,
-            "phantasm": 400
-        },
-        "resistances": {
-            "missile": 100,
-            "fire": 100,
-            "poison": 50,
-            "breath": 0,
-            "magic": 50,
-            "melee": 100,
-            "ranged": 100,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 50,
-            "holy": 0
-        },
-        "abilities": [
-            "endurance",
-            "flying",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Succubus",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 29,
-        "hp": 50,
-        "a1_power": 200,
-        "a1_type": "psychic",
-        "a1_init": 3,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 50,
-            "phantasm": 25
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 80,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 100,
-            "holy": 0
-        },
-        "abilities": [
-            "beauty",
-            "charm",
-            "endurance",
-            "flying",
-            "swift"
-        ]
-    },
-    {
-        "name": "Fallen Angel",
-        "magic": "nether",
-        "race": [
-            "angel"
-        ],
-        "power": 193,
-        "hp": 1500,
-        "a1_power": 2400,
-        "a1_type": "magic",
-        "a1_init": 2,
-        "counter": 400,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 25,
-            "eradication": 25,
-            "nether": 50,
-            "phantasm": 25
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 50,
-            "poison": 25,
-            "breath": 25,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 55,
-            "cold": 50,
-            "paralyse": 25,
-            "psychic": 50,
-            "holy": 25
-        },
-        "abilities": [
-            "beauty",
-            "flying",
-            "healing",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Fallen Archangel",
-        "magic": "nether",
-        "race": [
-            "angel"
-        ],
-        "power": 750,
-        "hp": 7500,
-        "a1_power": 12000,
-        "a1_type": "magic",
-        "a1_init": 2,
-        "counter": 800,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 70,
-            "verdant": 35,
-            "eradication": 35,
-            "nether": 70,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 75,
-            "fire": 75,
-            "poison": 25,
-            "breath": 25,
-            "magic": 75,
-            "melee": 75,
-            "ranged": 75,
-            "lightning": 80,
-            "cold": 75,
-            "paralyse": 25,
-            "psychic": 75,
-            "holy": 50
-        },
-        "abilities": [
-            "beauty",
-            "flying",
-            "healing",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Fallen Dominion",
-        "magic": "nether",
-        "race": [
-            "angel"
-        ],
-        "power": 59020,
-        "hp": 120000,
-        "a1_power": 600000,
-        "a1_type": "magic",
-        "a1_init": 2,
-        "counter": 60000,
-        "a2_power": 800000,
-        "a2_type": "magic",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 80,
-            "verdant": 50,
-            "eradication": 80,
-            "nether": 80,
-            "phantasm": 50
-        },
-        "resistances": {
-            "missile": 85,
-            "fire": 85,
-            "poison": 85,
-            "breath": 85,
-            "magic": 85,
-            "melee": 85,
-            "ranged": 85,
-            "lightning": 90,
-            "cold": 85,
-            "paralyse": 85,
-            "psychic": 85,
-            "holy": 80
-        },
-        "abilities": [
-            "beauty",
-            "fear",
-            "flying",
-            "healing",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Shadow",
-        "magic": "nether",
-        "race": [
-            "undead"
-        ],
-        "power": 40,
-        "hp": 250,
-        "a1_power": 600,
-        "a1_type": "magic",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 100,
-            "fire": 0,
-            "poison": 40,
-            "breath": 0,
-            "magic": 0,
-            "melee": 100,
-            "ranged": 20,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 100,
-            "psychic": 25,
-            "holy": 0
-        },
-        "abilities": [
-            "steal life 5%",
-            "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Horned Demon",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 170,
-        "hp": 950,
-        "a1_power": 2750,
-        "a1_type": "poison melee",
-        "a1_init": 1,
-        "counter": 450,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 50,
-            "poison": 75,
-            "breath": 0,
-            "magic": 25,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 20,
-            "psychic": 0,
-            "holy": 25
-        },
-        "abilities": [
-            "additional strike",
-            "swift",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Demon Knight",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 1850,
-        "hp": 8500,
-        "a1_power": 10000,
-        "a1_type": "cold melee",
-        "a1_init": 2,
-        "counter": 6000,
-        "a2_power": 8000,
-        "a2_type": "poison ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 25,
-            "eradication": 60,
-            "nether": 0,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 70,
-            "fire": 60,
-            "poison": 75,
-            "breath": 0,
-            "magic": 60,
-            "melee": 85,
-            "ranged": 70,
-            "lightning": 70,
-            "cold": 75,
-            "paralyse": 60,
-            "psychic": 50,
-            "holy": 30
-        },
-        "abilities": [
-            "additional strike",
-            "endurance",
-            "steal life 5%",
-            "swift",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Unholy Reaver",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 50000,
-        "hp": 85000,
-        "a1_power": 210000,
-        "a1_type": "melee paralyse",
-        "a1_init": 2,
-        "counter": 30000,
-        "a2_power": 470000,
-        "a2_type": "psychic ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 80,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 80,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 95,
-            "fire": 50,
-            "poison": 70,
-            "breath": 70,
-            "magic": 70,
-            "melee": 95,
-            "ranged": 75,
-            "lightning": 70,
-            "cold": 70,
-            "paralyse": 85,
-            "psychic": 85,
-            "holy": 30
-        },
-        "abilities": [
-            "additional strike",
-            "endurance",
-            "fear",
-            "marksmanship",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Dark Elf Magician",
-        "magic": "nether",
-        "race": [
-            "elf"
-        ],
-        "power": 666,
-        "hp": 4500,
-        "a1_power": 4500,
-        "a1_type": "fire ranged",
-        "a1_init": 3,
-        "counter": 0,
-        "a2_power": 3000,
-        "a2_type": "ranged lightning",
-        "a2_init": 4,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 80,
-            "eradication": 80,
-            "nether": 0,
-            "phantasm": 25
-        },
-        "resistances": {
-            "missile": 85,
-            "fire": 70,
-            "poison": 0,
-            "breath": 0,
-            "magic": 90,
-            "melee": 90,
-            "ranged": 75,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 40,
-            "psychic": 0,
-            "holy": 25
-        },
-        "abilities": [
-            "marksmanship"
-        ]
-    },
-    {
-        "name": "Bulwark Horror",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 2018,
-        "hp": 10750,
-        "a1_power": 13600,
-        "a1_type": "melee poison",
-        "a1_init": 1,
-        "counter": 4900,
-        "a2_power": 9000,
-        "a2_type": "cold ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 0,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 40,
-            "fire": 60,
-            "poison": 50,
-            "breath": 70,
-            "magic": 20,
-            "melee": 90,
-            "ranged": 40,
-            "lightning": 30,
-            "cold": 40,
-            "paralyse": 30,
-            "psychic": 30,
-            "holy": 50
-        },
-        "abilities": [
-            "endurance",
-            "large shield",
-            "pike",
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Sprite",
-        "magic": "phantasm",
-        "race": [
-            "pixie"
-        ],
-        "power": 38,
-        "hp": 75,
-        "a1_power": 400,
-        "a1_type": "magic",
-        "a1_init": 5,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 10
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "beauty",
-            "flying",
-            "swift"
-        ]
-    },
-    {
-        "name": "Sylph",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 68,
-        "hp": 150,
-        "a1_power": 1000,
-        "a1_type": "magic",
-        "a1_init": 3,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 33,
-            "nether": 33,
-            "phantasm": 15
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "beauty",
-            "flying",
-            "swift"
-        ]
-    },
-    {
-        "name": "Siren",
-        "magic": "phantasm",
-        "race": [
-            "pixie"
-        ],
-        "power": 176,
-        "hp": 600,
-        "a1_power": 3400,
-        "a1_type": "psychic",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 600,
-        "a2_type": "melee",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 25
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 25,
-            "melee": 33,
-            "ranged": 33,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 50,
-            "holy": 25
-        },
-        "abilities": [
-            "beauty",
-            "charm"
-        ]
-    },
-    {
-        "name": "Shadow Monster",
-        "magic": "phantasm",
-        "race": [
-            "illusion"
-        ],
-        "power": 6,
-        "hp": 1,
-        "a1_power": 400,
-        "a1_type": "psychic",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": []
-    },
-    {
-        "name": "Mind Ripper",
-        "magic": "phantasm",
-        "race": [
-            "telepath"
-        ],
-        "power": 1154,
-        "hp": 5000,
-        "a1_power": 8000,
-        "a1_type": "magic ranged",
-        "a1_init": 3,
-        "counter": 4000,
-        "a2_power": 16000,
-        "a2_type": "ranged psychic",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 75,
-            "phantasm": 30
-        },
-        "resistances": {
-            "missile": 75,
-            "fire": 50,
-            "poison": 20,
-            "breath": 50,
-            "magic": 75,
-            "melee": 75,
-            "ranged": 75,
-            "lightning": 20,
-            "cold": 30,
-            "paralyse": 50,
-            "psychic": 90,
-            "holy": 50
-        },
-        "abilities": [
-            "undisbandable"
-        ]
-    },
-    {
-        "name": "Air Elemental",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 25000,
-        "hp": 60000,
-        "a1_power": 300000,
-        "a1_type": "lightning ranged",
-        "a1_init": 4,
-        "counter": 6500,
-        "a2_power": 200000,
-        "a2_type": "magic",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 95,
-            "fire": 50,
-            "poison": 0,
-            "breath": 70,
-            "magic": 55,
-            "melee": 95,
-            "ranged": 95,
-            "lightning": 100,
-            "cold": 0,
-            "paralyse": 20,
-            "psychic": 50,
-            "holy": 80
-        },
-        "abilities": [
-            "flying",
-            "swift"
-        ]
-    },
-    {
-        "name": "Water Elemental",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 19406,
-        "hp": 72000,
-        "a1_power": 400000,
-        "a1_type": "poison ranged",
-        "a1_init": 2,
-        "counter": 5000,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 100,
-            "fire": 50,
-            "poison": 100,
-            "breath": 0,
-            "magic": 50,
-            "melee": 100,
-            "ranged": 75,
-            "lightning": 100,
-            "cold": 25,
-            "paralyse": 100,
-            "psychic": 50,
-            "holy": 80
-        },
-        "abilities": [
-            "endurance"
-        ]
-    },
-    {
-        "name": "Ice Elemental",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 21800,
-        "hp": 90000,
-        "a1_power": 200000,
-        "a1_type": "cold ranged",
-        "a1_init": 1,
-        "counter": 10000,
-        "a2_power": 300000,
-        "a2_type": "cold ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 80,
-            "nether": 75,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 85,
-            "fire": 0,
-            "poison": 100,
-            "breath": 0,
-            "magic": 75,
-            "melee": 85,
-            "ranged": 85,
-            "lightning": 80,
-            "cold": 100,
-            "paralyse": 100,
-            "psychic": 50,
-            "holy": 80
-        },
-        "abilities": [
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "Psychic Wisp",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 40,
-        "hp": 100,
-        "a1_power": 460,
-        "a1_type": "ranged psychic",
-        "a1_init": 3,
-        "counter": 200,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 25,
-            "nether": 25,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 80,
-            "holy": 0
-        },
-        "abilities": [
-            "swift"
-        ]
-    },
-    {
-        "name": "Medusa",
-        "magic": "phantasm",
-        "race": [
-            "reptile"
-        ],
-        "power": 200,
-        "hp": 650,
-        "a1_power": 2000,
-        "a1_type": "paralyse",
-        "a1_init": 2,
-        "counter": 300,
-        "a2_power": 1000,
-        "a2_type": "poison ranged",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 30,
-            "nether": 40,
-            "phantasm": 30
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 60,
-            "breath": 0,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 50,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "fear",
-            "scales"
-        ]
-    },
-    {
-        "name": "Djinni",
-        "magic": "phantasm",
-        "race": [
-            "elemental"
-        ],
-        "power": 1700,
-        "hp": 7650,
-        "a1_power": 8000,
-        "a1_type": "magic",
-        "a1_init": 2,
-        "counter": 1200,
-        "a2_power": 12000,
-        "a2_type": "lightning ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 65,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 80,
-            "fire": 60,
-            "poison": 0,
-            "breath": 60,
-            "magic": 50,
-            "melee": 80,
-            "ranged": 95,
-            "lightning": 90,
-            "cold": 50,
-            "paralyse": 40,
-            "psychic": 50,
-            "holy": 50
-        },
-        "abilities": [
-            "flying",
-            "marksmanship"
-        ]
-    },
-    {
-        "name": "Leviathan",
-        "magic": "phantasm",
-        "race": [
-            "giant"
-        ],
-        "power": 49500,
-        "hp": 100000,
-        "a1_power": 200000,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 50000,
-        "a2_power": 300000,
-        "a2_type": "poison ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 90,
-            "phantasm": 80
-        },
-        "resistances": {
-            "missile": 95,
-            "fire": 50,
-            "poison": 100,
-            "breath": 80,
-            "magic": 90,
-            "melee": 95,
-            "ranged": 95,
-            "lightning": 70,
-            "cold": 80,
-            "paralyse": 90,
-            "psychic": 70,
-            "holy": 80
-        },
-        "abilities": [
-            "additional strike",
-            "endurance",
-            "marksmanship",
-            "scales"
-        ]
-    },
-    {
-        "name": "Yeti",
-        "magic": "phantasm",
-        "race": [
-            "giant"
-        ],
-        "power": 180,
-        "hp": 1000,
-        "a1_power": 500,
-        "a1_type": "cold",
-        "a1_init": 2,
-        "counter": 500,
-        "a2_power": 1400,
-        "a2_type": "breath cold",
-        "a2_init": 2,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 0,
-            "eradication": 40,
-            "nether": 0,
-            "phantasm": 80
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 40,
-            "breath": 50,
-            "magic": 60,
-            "melee": 30,
-            "ranged": 65,
-            "lightning": 10,
-            "cold": 80,
-            "paralyse": 10,
-            "psychic": 0,
-            "holy": 85
-        },
-        "abilities": [
-            "marksmanship",
-            "swift",
-            "weak to attack type fire"
-        ]
-    },
-    {
-        "name": "Phantom",
-        "magic": "phantasm",
-        "race": [
-            "illusion"
-        ],
-        "power": 20,
-        "hp": 130,
-        "a1_power": 100,
-        "a1_type": "psychic ranged",
-        "a1_init": 1,
-        "counter": 350,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 75,
-            "breath": 0,
-            "magic": 0,
-            "melee": 100,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 100,
-            "holy": 50
-        },
-        "abilities": [
-            "fear",
-            "recruit speed -15%",
-            "weaken resistance to magic"
-        ]
-    },
-    {
-        "name": "Stone Golem",
-        "magic": "plain",
-        "race": [
-            "golem"
-        ],
-        "power": 1984,
-        "hp": 15000,
-        "a1_power": 20000,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 20000,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 75,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 75,
-            "phantasm": 75
-        },
-        "resistances": {
-            "missile": 99,
-            "fire": 50,
-            "poison": 100,
-            "breath": 0,
-            "magic": 50,
-            "melee": 99,
-            "ranged": 99,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 100,
-            "psychic": 100,
-            "holy": 100
-        },
-        "abilities": [
-            "clumsiness",
-            "endurance",
-            "siege"
-        ]
-    },
-    {
-        "name": "Mercenary",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 68,
-        "hp": 300,
-        "a1_power": 600,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 300,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 33,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "additional strike",
-            "marksmanship"
-        ]
-    },
-    {
-        "name": "Renegade Wizard",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 72,
-        "hp": 100,
-        "a1_power": 1600,
-        "a1_type": "magic ranged",
-        "a1_init": 3,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 50,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 80,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 50,
-            "melee": 80,
-            "ranged": 80,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 80,
-            "holy": 30
-        },
-        "abilities": []
-    },
-    {
-        "name": "Venomesse",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 45,
-        "hp": 200,
-        "a1_power": 500,
-        "a1_type": "poison",
-        "a1_init": 2,
-        "counter": 50,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 33,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "marksmanship",
-            "swift"
-        ]
-    },
-    {
-        "name": "Bounty Hunter",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 46,
-        "hp": 250,
-        "a1_power": 200,
-        "a1_type": "missile ranged",
-        "a1_init": 1,
-        "counter": 50,
-        "a2_power": 300,
-        "a2_type": "missile ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 25,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "marksmanship"
-        ]
-    },
-    {
-        "name": "Starving Peasant",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 2,
-        "hp": 20,
-        "a1_power": 50,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "clumsiness"
-        ]
-    },
-    {
-        "name": "War Hound",
-        "magic": "plain",
-        "race": [
-            "animal"
-        ],
-        "power": 53,
-        "hp": 400,
-        "a1_power": 400,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 200,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": []
-    },
-    {
-        "name": "Falcon",
-        "magic": "plain",
-        "race": [
-            "animal"
-        ],
-        "power": 15,
-        "hp": 50,
-        "a1_power": 200,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
-        "name": "Trained Elephant",
-        "magic": "plain",
-        "race": [
-            "animal"
-        ],
-        "power": 107,
-        "hp": 1000,
-        "a1_power": 1000,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 200,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "clumsiness"
-        ]
-    },
-    {
-        "name": "Fanatic",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 12,
-        "hp": 500,
-        "a1_power": 500,
-        "a1_type": "holy",
-        "a1_init": 1,
-        "counter": 500,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 50,
-            "nether": 50,
-            "phantasm": 25
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 50,
-            "poison": 50,
-            "breath": 50,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 50,
-            "cold": 50,
-            "paralyse": 50,
-            "psychic": 50,
-            "holy": 50
-        },
-        "abilities": [
-            "additional strike"
-        ]
-    },
-    {
-        "name": "Capsule Monster",
-        "magic": "plain",
-        "race": [
-            "animal"
-        ],
-        "power": 21,
-        "hp": 1,
-        "a1_power": 500,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 100,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
-        "name": "Sheep",
-        "magic": "plain",
-        "race": [
-            "animal"
-        ],
-        "power": 1,
-        "hp": 10,
-        "a1_power": 10,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 100,
-            "holy": 0
-        },
-        "abilities": []
-    },
-    {
-        "name": "Frog",
-        "magic": "plain",
-        "race": [
-            "animal"
-        ],
-        "power": 1,
-        "hp": 10,
-        "a1_power": 10,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 100,
-            "holy": 0
-        },
-        "abilities": []
-    },
-    {
-        "name": "Squirrel",
-        "magic": "plain",
-        "race": [
-            "animal"
-        ],
-        "power": 1,
-        "hp": 10,
-        "a1_power": 10,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 100,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
-        "name": "Werewolf",
-        "magic": "plain",
-        "race": [
-            "human",
-            "animal"
-        ],
-        "power": 190,
-        "hp": 1000,
-        "a1_power": 2300,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 400,
-        "a2_power": 2300,
-        "a2_type": "melee",
-        "a2_init": 2,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 50,
-            "fire": 0,
-            "poison": 67,
-            "breath": 0,
-            "magic": 50,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 75,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 25
-        },
-        "abilities": [
-            "additional strike",
-            "endurance",
-            "regeneration"
         ]
     }
 ]

--- a/data/guild/enchantments.json
+++ b/data/guild/enchantments.json
@@ -1,0 +1,234 @@
+[
+  {
+    "id": "thl",
+    "name": "The holy light",
+    "magic": "ascendant",
+    "effects": [
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null, 
+          "value": 0.1263
+        }
+      },
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["accuracy"],
+          "type": "change value",
+          "base": 1,
+          "value": 0.06315
+        }
+      },
+      {
+        "filters": [
+          {
+            "magic": "ascendant",
+            "primaryTypes": ["melee"]
+          },
+          {
+            "magic": "ascendant",
+            "secondaryTypes": ["melee"]
+          }
+        ],
+        "action": {
+          "attributes": ["primaryTypes"],
+          "type": "add attack type",
+          "value": "holy"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lnp",
+    "name": "Love and Peace",
+    "magic": "ascendant",
+    "effects": [
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": -0.2
+        }
+      },
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.25
+        }
+      }
+    ]
+  },
+  {
+    "id": "lore",
+    "name": "Nature's Lore",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["elf"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.13
+        }
+      },
+      {
+        "filters": [
+          { "race": ["elf"] }
+        ],
+        "action": {
+          "attributes": ["accuracy"],
+          "type": "change value",
+          "base": 1,
+          "value": 0.07
+        }
+      },
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.25
+        }
+      },
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.20
+        }
+      }
+    ]
+  },
+  {
+    "id": "pg",
+    "name": "Plant Growth",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["treefolk"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "counterPower", "hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.9524
+        }
+      }
+    ]
+  },
+  {
+    "id": "ea",
+    "name": "Enlarge Animal",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.47
+        }
+      }
+    ]
+  },
+  {
+    "id": "bc",
+    "name": "Battle Chant",
+    "magic": "eradication",
+    "effects": [
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.2
+        }
+      },
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": -0.1
+        }
+      }
+    ]
+  },
+  {
+    "id": "bs",
+    "name": "Black Sabbath",
+    "magic": "nether",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["demon"] }
+        ],
+        "action": {
+          "attributes": ["resistances.holy"],
+          "type": "change value",
+          "base": 100,
+          "value": 0.329
+        }
+      },
+      {
+        "filters": [
+          { "race": ["undead"] }
+        ],
+        "action": {
+          "attributes": ["resistances.holy"],
+          "type": "change value",
+          "base": 100,
+          "value": 0.329
+        }
+      }
+    ]
+  },
+  {
+    "id": "hallu",
+    "name": "Hallucination",
+    "magic": "phantasm",
+    "effects": [
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["efficiency"],
+          "type": "change value",
+          "base": 100,
+          "value": -0.1
+        }
+      }
+    ]
+  }
+]

--- a/data/guild/units.json
+++ b/data/guild/units.json
@@ -245,48 +245,6 @@
         ]
     },
     {
-        "name": "Bulwark Horror",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 2018,
-        "hp": 10750,
-        "a1_power": 13600,
-        "a1_type": "melee poison",
-        "a1_init": 1,
-        "counter": 4900,
-        "a2_power": 9000,
-        "a2_type": "cold ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 0,
-            "phantasm": 35
-        },
-        "resistances": {
-            "missile": 40,
-            "fire": 60,
-            "poison": 50,
-            "breath": 70,
-            "magic": 20,
-            "melee": 90,
-            "ranged": 40,
-            "lightning": 30,
-            "cold": 40,
-            "paralyse": 30,
-            "psychic": 30,
-            "holy": 50
-        },
-        "abilities": [
-            "endurance",
-            "large shield",
-            "pike"
-        ]
-    },
-    {
         "name": "Capsule Monster",
         "magic": "plain",
         "race": [
@@ -408,6 +366,47 @@
         ]
     },
     {
+        "name": "Cave Troll",
+        "magic": "nether",
+        "race": [
+            "troll"
+        ],
+        "power": 49,
+        "hp": 400,
+        "a1_power": 400,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 100,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "regeneration",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
         "name": "Chimera",
         "magic": "eradication",
         "race": [
@@ -491,6 +490,47 @@
         ]
     },
     {
+        "name": "Crusader",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 14,
+        "hp": 130,
+        "a1_power": 160,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 40,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed 50%"
+        ]
+    },
+    {
         "name": "Dark Apprentice",
         "magic": "nether",
         "race": [
@@ -530,47 +570,6 @@
             "marksmanship",
             "recruit speed -10%",
             "swift"
-        ]
-    },
-    {
-        "name": "Dark Elemental",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 20586,
-        "hp": 80000,
-        "a1_power": 100000,
-        "a1_type": "paralyse",
-        "a1_init": 1,
-        "counter": 15000,
-        "a2_power": 300000,
-        "a2_type": "paralyse ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 0,
-            "eradication": 40,
-            "nether": 80,
-            "phantasm": 80
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 60,
-            "poison": 90,
-            "breath": 50,
-            "magic": 60,
-            "melee": 100,
-            "ranged": 85,
-            "lightning": 50,
-            "cold": 50,
-            "paralyse": 100,
-            "psychic": 50,
-            "holy": 20
-        },
-        "abilities": [
-            "endurance",
-            "steal life 5%"
         ]
     },
     {
@@ -637,7 +636,7 @@
         },
         "resistances": {
             "missile": 70,
-            "fire": 75,
+            "fire": 60,
             "poison": 75,
             "breath": 0,
             "magic": 60,
@@ -703,7 +702,7 @@
         "race": [
             "elemental"
         ],
-        "power": 1550,
+        "power": 1700,
         "hp": 7650,
         "a1_power": 8000,
         "a1_type": "magic",
@@ -780,6 +779,46 @@
         ]
     },
     {
+        "name": "Druid",
+        "magic": "verdant",
+        "race": [
+            "elf"
+        ],
+        "power": 40,
+        "hp": 180,
+        "a1_power": 440,
+        "a1_type": "magic ranged",
+        "a1_init": 3,
+        "counter": 60,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 25,
+            "poison": 90,
+            "breath": 0,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 25,
+            "cold": 25,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 25
+        },
+        "abilities": [
+            "recruit speed -15%"
+        ]
+    },
+    {
         "name": "Dryad",
         "magic": "verdant",
         "race": [
@@ -818,46 +857,6 @@
         "abilities": [
             "beauty",
             "charm"
-        ]
-    },
-    {
-        "name": "Dwarven Batrider",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 24,
-        "hp": 180,
-        "a1_power": 120,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
         ]
     },
     {
@@ -943,46 +942,6 @@
         ]
     },
     {
-        "name": "Dwarven Gunslinger",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 18,
-        "hp": 130,
-        "a1_power": 90,
-        "a1_type": "missile ranged",
-        "a1_init": 4,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "piercing"
-        ]
-    },
-    {
         "name": "Dwarven Shaman",
         "magic": "eradication",
         "race": [
@@ -1020,6 +979,48 @@
         },
         "abilities": [
             "healing"
+        ]
+    },
+    {
+        "name": "Dwarven Warrior",
+        "magic": "eradication",
+        "race": [
+            "dwarf"
+        ],
+        "power": 20,
+        "hp": 160,
+        "a1_power": 200,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 25,
+            "breath": 0,
+            "magic": 15,
+            "melee": 25,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 10
+        },
+        "abilities": [
+            "racial enemy against orc 50%",
+            "endurance",
+            "recruit speed 30%"
         ]
     },
     {
@@ -1147,51 +1148,6 @@
         ]
     },
     {
-        "name": "Elven Blade Dancer",
-        "magic": "verdant",
-        "race": [
-            "elf"
-        ],
-        "power": 1850,
-        "hp": 6500,
-        "a1_power": 9000,
-        "a1_type": "melee",
-        "a1_init": 4,
-        "counter": 1500,
-        "a2_power": 13500,
-        "a2_type": "paralyse ranged",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 80,
-            "eradication": 80,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 75,
-            "fire": 70,
-            "poison": 0,
-            "breath": 75,
-            "magic": 55,
-            "melee": 100,
-            "ranged": 75,
-            "lightning": 20,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 40,
-            "holy": 20
-        },
-        "abilities": [
-            "additional strike",
-            "racial enemy against angel 50%",
-            "beauty",
-            "bursting melee 3000",
-            "swift",
-            "weakness to attacktype cold"
-        ]
-    },
-    {
         "name": "Elven Magician",
         "magic": "verdant",
         "race": [
@@ -1231,88 +1187,6 @@
             "marksmanship",
             "recruit speed -10%",
             "swift"
-        ]
-    },
-    {
-        "name": "Elven Scout",
-        "magic": "verdant",
-        "race": [
-            "elf"
-        ],
-        "power": 20,
-        "hp": 120,
-        "a1_power": 80,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 30,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "-"
-        ]
-    },
-    {
-        "name": "Empyrean Inquisitor",
-        "magic": "ascendant",
-        "race": [
-            "astral"
-        ],
-        "power": 2500,
-        "hp": 9000,
-        "a1_power": 13500,
-        "a1_type": "magic",
-        "a1_init": 4,
-        "counter": 1900,
-        "a2_power": 2500,
-        "a2_type": "melee",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 30,
-            "nether": 50,
-            "phantasm": 20
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 75,
-            "poison": 0,
-            "breath": 35,
-            "magic": 75,
-            "melee": 80,
-            "ranged": 70,
-            "lightning": 20,
-            "cold": 10,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 30
-        },
-        "abilities": [
-            "charm",
-            "fear",
-            "weakness to attacktype poison"
         ]
     },
     {
@@ -1532,7 +1406,7 @@
         ],
         "power": 12,
         "hp": 500,
-        "a1_power": 300,
+        "a1_power": 500,
         "a1_type": "holy",
         "a1_init": 1,
         "counter": 500,
@@ -1688,6 +1562,46 @@
         ]
     },
     {
+        "name": "Gargoyle",
+        "magic": "nether",
+        "race": [
+            "golem"
+        ],
+        "power": 64,
+        "hp": 300,
+        "a1_power": 400,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 25,
+            "melee": 25,
+            "ranged": 25,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
         "name": "Ghoul",
         "magic": "nether",
         "race": [
@@ -1707,7 +1621,7 @@
             "verdant": 0,
             "eradication": 0,
             "nether": 0,
-            "phantasm": 25
+            "phantasm": 0
         },
         "resistances": {
             "missile": 0,
@@ -1726,48 +1640,6 @@
         "abilities": [
             "steal life 5%",
             "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Goblin",
-        "magic": "eradication",
-        "race": [
-            "orc"
-        ],
-        "power": 13,
-        "hp": 180,
-        "a1_power": 125,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 50,
-        "a2_power": 75,
-        "a2_type": "ranged missile",
-        "a2_init": 1,
-        "spell_resistance": {
-            "ascendant": 25,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 25,
-            "fire": 50,
-            "poison": 0,
-            "breath": 25,
-            "magic": 0,
-            "melee": 50,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "racial enemy against human 100%",
-            "clumsiness",
-            "weaken resistance to ranged"
         ]
     },
     {
@@ -1975,46 +1847,6 @@
         ]
     },
     {
-        "name": "Holy Spirit",
-        "magic": "ascendant",
-        "race": [
-            "elemental"
-        ],
-        "power": 29,
-        "hp": 200,
-        "a1_power": 140,
-        "a1_type": "holy",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
         "name": "Horned Demon",
         "magic": "nether",
         "race": [
@@ -2088,7 +1920,7 @@
             "lightning": 45,
             "cold": 0,
             "paralyse": 45,
-            "psychic": 80,
+            "psychic": 45,
             "holy": 50
         },
         "abilities": [
@@ -2180,6 +2012,47 @@
         ]
     },
     {
+        "name": "Knight",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 23,
+        "hp": 200,
+        "a1_power": 250,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed -15%"
+        ]
+    },
+    {
         "name": "Knight Templar",
         "magic": "ascendant",
         "race": [
@@ -2259,7 +2132,6 @@
         },
         "abilities": [
             "additional strike",
-            "racial enemy against animal 50%",
             "endurance",
             "marksmanship",
             "scales"
@@ -2426,7 +2298,6 @@
             "holy": 0
         },
         "abilities": [
-            "racial enemy against human 50%",
             "fear",
             "scales"
         ]
@@ -2642,8 +2513,8 @@
             "giant"
         ],
         "power": 34,
-        "hp": 700,
-        "a1_power": 300,
+        "hp": 300,
+        "a1_power": 400,
         "a1_type": "melee",
         "a1_init": 2,
         "counter": 100,
@@ -2672,7 +2543,6 @@
             "holy": 0
         },
         "abilities": [
-            "clumsiness",
             "endurance",
             "recruit speed 10%"
         ]
@@ -2878,48 +2748,6 @@
         },
         "abilities": [
             "large shield"
-        ]
-    },
-    {
-        "name": "Phantom",
-        "magic": "phantasm",
-        "race": [
-            "illusion"
-        ],
-        "power": 20,
-        "hp": 130,
-        "a1_power": 100,
-        "a1_type": "psychic ranged",
-        "a1_init": 1,
-        "counter": 350,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 75,
-            "breath": 0,
-            "magic": 0,
-            "melee": 100,
-            "ranged": 50,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 100,
-            "holy": 50
-        },
-        "abilities": [
-            "fear",
-            "recruit speed -15%",
-            "weaken resistance to magic"
         ]
     },
     {
@@ -3206,7 +3034,6 @@
             "holy": 25
         },
         "abilities": [
-            "racial enemy against treefolk 50%",
             "scales",
             "weakness to attacktype cold"
         ]
@@ -3491,11 +3318,9 @@
             "holy": 0
         },
         "abilities": [
-            "racial enemy against demon 50%",
             "beauty",
             "charm",
-            "endurance",
-            "healing"
+            "endurance"
         ]
     },
     {
@@ -3618,90 +3443,6 @@
         },
         "abilities": [
             "clumsiness"
-        ]
-    },
-    {
-        "name": "Stone Golem",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 1984,
-        "hp": 15000,
-        "a1_power": 20000,
-        "a1_type": "melee",
-        "a1_init": 1,
-        "counter": 20000,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 75,
-            "verdant": 75,
-            "eradication": 75,
-            "nether": 75,
-            "phantasm": 75
-        },
-        "resistances": {
-            "missile": 99,
-            "fire": 50,
-            "poison": 100,
-            "breath": 0,
-            "magic": 50,
-            "melee": 99,
-            "ranged": 99,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 100,
-            "psychic": 100,
-            "holy": 100
-        },
-        "abilities": [
-            "clumsiness",
-            "endurance",
-            "siege"
-        ]
-    },
-    {
-        "name": "Storm Giant",
-        "magic": "eradication",
-        "race": [
-            "giant"
-        ],
-        "power": 1550,
-        "hp": 5800,
-        "a1_power": 16000,
-        "a1_type": "lightning breath",
-        "a1_init": 3,
-        "counter": 300,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 75,
-            "eradication": 40,
-            "nether": 0,
-            "phantasm": 75
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 70,
-            "poison": 30,
-            "breath": 80,
-            "magic": 0,
-            "melee": 75,
-            "ranged": 70,
-            "lightning": 100,
-            "cold": 85,
-            "paralyse": 45,
-            "psychic": 50,
-            "holy": 70
-        },
-        "abilities": [
-            "endurance",
-            "marksmanship",
-            "siege"
         ]
     },
     {
@@ -3960,6 +3701,47 @@
         ]
     },
     {
+        "name": "Troglodyte",
+        "magic": "eradication",
+        "race": [
+            "reptile"
+        ],
+        "power": 22,
+        "hp": 160,
+        "a1_power": 200,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 35,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "recruit speed 35%",
+            "scales"
+        ]
+    },
+    {
         "name": "Unholy Reaver",
         "magic": "nether",
         "race": [
@@ -3997,7 +3779,6 @@
         },
         "abilities": [
             "additional strike",
-            "racial enemy against elemental 50%",
             "endurance",
             "fear",
             "marksmanship"
@@ -4050,7 +3831,7 @@
         "race": [
             "undead"
         ],
-        "power": 1858,
+        "power": 2058,
         "hp": 4500,
         "a1_power": 9000,
         "a1_type": "magic paralyse",
@@ -4087,89 +3868,6 @@
             "steal life 5%",
             "swift",
             "weaken resistance to holy"
-        ]
-    },
-    {
-        "name": "Venomesse",
-        "magic": "plain",
-        "race": [
-            "human"
-        ],
-        "power": 45,
-        "hp": 200,
-        "a1_power": 500,
-        "a1_type": "poison",
-        "a1_init": 2,
-        "counter": 50,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 33,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "marksmanship",
-            "swift"
-        ]
-    },
-    {
-        "name": "Venus Flytrap",
-        "magic": "verdant",
-        "race": [
-            "treefolk"
-        ],
-        "power": 380,
-        "hp": 1344,
-        "a1_power": 1754,
-        "a1_type": "ranged poison",
-        "a1_init": 1,
-        "counter": 336,
-        "a2_power": 3000,
-        "a2_type": "ranged poison",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 40,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 40
-        },
-        "resistances": {
-            "missile": 67,
-            "fire": 0,
-            "poison": 90,
-            "breath": 20,
-            "magic": 50,
-            "melee": 67,
-            "ranged": 67,
-            "lightning": 40,
-            "cold": 40,
-            "paralyse": 75,
-            "psychic": 85,
-            "holy": 40
-        },
-        "abilities": [
-            "charm",
-            "regeneration",
-            "weakness to attacktype fire"
         ]
     },
     {
@@ -4260,7 +3958,7 @@
             "animal"
         ],
         "power": 161,
-        "hp": 1000,
+        "hp": 1500,
         "a1_power": 2300,
         "a1_type": "melee",
         "a1_init": 1,
@@ -4384,7 +4082,7 @@
         "race": [
             "undead"
         ],
-        "power": 130,
+        "power": 160,
         "hp": 1000,
         "a1_power": 2400,
         "a1_type": "magic paralyse",
@@ -4426,7 +4124,7 @@
         "race": [
             "dragon"
         ],
-        "power": 150,
+        "power": 190,
         "hp": 1000,
         "a1_power": 800,
         "a1_type": "melee poison",

--- a/data/lightning/enchantments.json
+++ b/data/lightning/enchantments.json
@@ -1,0 +1,234 @@
+[
+  {
+    "id": "thl",
+    "name": "The holy light",
+    "magic": "ascendant",
+    "effects": [
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null, 
+          "value": 0.1263
+        }
+      },
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["accuracy"],
+          "type": "change value",
+          "base": 1,
+          "value": 0.06315
+        }
+      },
+      {
+        "filters": [
+          {
+            "magic": "ascendant",
+            "primaryTypes": ["melee"]
+          },
+          {
+            "magic": "ascendant",
+            "secondaryTypes": ["melee"]
+          }
+        ],
+        "action": {
+          "attributes": ["primaryTypes"],
+          "type": "add attack type",
+          "value": "holy"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lnp",
+    "name": "Love and Peace",
+    "magic": "ascendant",
+    "effects": [
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": -0.2
+        }
+      },
+      {
+        "filters": [
+          { "magic": "ascendant" }
+        ],
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.25
+        }
+      }
+    ]
+  },
+  {
+    "id": "lore",
+    "name": "Nature's Lore",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["elf"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.13
+        }
+      },
+      {
+        "filters": [
+          { "race": ["elf"] }
+        ],
+        "action": {
+          "attributes": ["accuracy"],
+          "type": "change value",
+          "base": 1,
+          "value": 0.07
+        }
+      },
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.25
+        }
+      },
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.20
+        }
+      }
+    ]
+  },
+  {
+    "id": "pg",
+    "name": "Plant Growth",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["treefolk"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "counterPower", "hp"],
+          "type": "change value",
+          "base": null,
+          "value": 0.9524
+        }
+      }
+    ]
+  },
+  {
+    "id": "ea",
+    "name": "Enlarge Animal",
+    "magic": "verdant",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["animal"] }
+        ],
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.47
+        }
+      }
+    ]
+  },
+  {
+    "id": "bc",
+    "name": "Battle Chant",
+    "magic": "eradication",
+    "effects": [
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["primaryPower", "secondaryPower", "counterPower"],
+          "type": "change value",
+          "base": null,
+          "value": 0.2
+        }
+      },
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["hp"],
+          "type": "change value",
+          "base": null,
+          "value": -0.1
+        }
+      }
+    ]
+  },
+  {
+    "id": "bs",
+    "name": "Black Sabbath",
+    "magic": "nether",
+    "effects": [
+      {
+        "filters": [
+          { "race": ["demon"] }
+        ],
+        "action": {
+          "attributes": ["resistances.holy"],
+          "type": "change value",
+          "base": 100,
+          "value": 0.329
+        }
+      },
+      {
+        "filters": [
+          { "race": ["undead"] }
+        ],
+        "action": {
+          "attributes": ["resistances.holy"],
+          "type": "change value",
+          "base": 100,
+          "value": 0.329
+        }
+      }
+    ]
+  },
+  {
+    "id": "hallu",
+    "name": "Hallucination",
+    "magic": "phantasm",
+    "effects": [
+      {
+        "filters": null,
+        "action": {
+          "attributes": ["efficiency"],
+          "type": "change value",
+          "base": 100,
+          "value": -0.1
+        }
+      }
+    ]
+  }
+]

--- a/data/lightning/units.json
+++ b/data/lightning/units.json
@@ -408,6 +408,47 @@
         ]
     },
     {
+        "name": "Cave Troll",
+        "magic": "nether",
+        "race": [
+            "troll"
+        ],
+        "power": 49,
+        "hp": 400,
+        "a1_power": 400,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 100,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "regeneration",
+            "weakness to attacktype fire"
+        ]
+    },
+    {
         "name": "Chimera",
         "magic": "eradication",
         "race": [
@@ -491,6 +532,47 @@
         ]
     },
     {
+        "name": "Crusader",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 14,
+        "hp": 130,
+        "a1_power": 160,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 40,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed 50%"
+        ]
+    },
+    {
         "name": "Dark Apprentice",
         "magic": "nether",
         "race": [
@@ -530,47 +612,6 @@
             "marksmanship",
             "recruit speed -10%",
             "swift"
-        ]
-    },
-    {
-        "name": "Dark Elemental",
-        "magic": "nether",
-        "race": [
-            "demon"
-        ],
-        "power": 20586,
-        "hp": 80000,
-        "a1_power": 100000,
-        "a1_type": "paralyse",
-        "a1_init": 1,
-        "counter": 15000,
-        "a2_power": 300000,
-        "a2_type": "paralyse ranged",
-        "a2_init": 3,
-        "spell_resistance": {
-            "ascendant": 50,
-            "verdant": 0,
-            "eradication": 40,
-            "nether": 80,
-            "phantasm": 80
-        },
-        "resistances": {
-            "missile": 90,
-            "fire": 60,
-            "poison": 90,
-            "breath": 50,
-            "magic": 60,
-            "melee": 100,
-            "ranged": 85,
-            "lightning": 50,
-            "cold": 50,
-            "paralyse": 100,
-            "psychic": 50,
-            "holy": 20
-        },
-        "abilities": [
-            "endurance",
-            "steal life 5%"
         ]
     },
     {
@@ -703,7 +744,7 @@
         "race": [
             "elemental"
         ],
-        "power": 1550,
+        "power": 1700,
         "hp": 7650,
         "a1_power": 8000,
         "a1_type": "magic",
@@ -780,6 +821,46 @@
         ]
     },
     {
+        "name": "Druid",
+        "magic": "verdant",
+        "race": [
+            "elf"
+        ],
+        "power": 40,
+        "hp": 180,
+        "a1_power": 440,
+        "a1_type": "magic ranged",
+        "a1_init": 3,
+        "counter": 60,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 50,
+            "nether": 50,
+            "phantasm": 25
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 25,
+            "poison": 90,
+            "breath": 0,
+            "magic": 50,
+            "melee": 50,
+            "ranged": 50,
+            "lightning": 25,
+            "cold": 25,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 25
+        },
+        "abilities": [
+            "recruit speed -15%"
+        ]
+    },
+    {
         "name": "Dryad",
         "magic": "verdant",
         "race": [
@@ -821,43 +902,44 @@
         ]
     },
     {
-        "name": "Dwarven Batrider",
-        "magic": "eradication",
+        "name": "Duke",
+        "magic": "ascendant",
         "race": [
-            "dwarf"
+            "human"
         ],
-        "power": 24,
-        "hp": 180,
-        "a1_power": 120,
-        "a1_type": "melee",
+        "power": 125,
+        "hp": 575,
+        "a1_power": 600,
+        "a1_type": "holy melee",
         "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
+        "counter": 175,
+        "a2_power": 650,
+        "a2_type": "ranged fire",
+        "a2_init": 3,
         "spell_resistance": {
-            "ascendant": 0,
+            "ascendant": 50,
             "verdant": 0,
             "eradication": 0,
             "nether": 0,
             "phantasm": 0
         },
         "resistances": {
-            "missile": 0,
-            "fire": 0,
+            "missile": 25,
+            "fire": 55,
             "poison": 0,
             "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
+            "magic": 45,
+            "melee": 75,
+            "ranged": 25,
             "lightning": 0,
             "cold": 0,
             "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
+            "psychic": 50,
+            "holy": 45
         },
         "abilities": [
-            "flying"
+            "racial enemy against human 50%",
+            "large shield"
         ]
     },
     {
@@ -898,6 +980,46 @@
         },
         "abilities": [
             "bursting poison 30"
+        ]
+    },
+    {
+        "name": "Dwarven Defender",
+        "magic": "eradication",
+        "race": [
+            "dwarf"
+        ],
+        "power": 240,
+        "hp": 1150,
+        "a1_power": 3275,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 50,
+            "eradication": 70,
+            "nether": 0,
+            "phantasm": 50
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 85,
+            "poison": 25,
+            "breath": 0,
+            "magic": 75,
+            "melee": 92,
+            "ranged": 55,
+            "lightning": 45,
+            "cold": 0,
+            "paralyse": 25,
+            "psychic": 25,
+            "holy": 75
+        },
+        "abilities": [
+            "racial enemy against elemental 50%"
         ]
     },
     {
@@ -943,46 +1065,6 @@
         ]
     },
     {
-        "name": "Dwarven Gunslinger",
-        "magic": "eradication",
-        "race": [
-            "dwarf"
-        ],
-        "power": 18,
-        "hp": 130,
-        "a1_power": 90,
-        "a1_type": "missile ranged",
-        "a1_init": 4,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "piercing"
-        ]
-    },
-    {
         "name": "Dwarven Shaman",
         "magic": "eradication",
         "race": [
@@ -1020,6 +1102,48 @@
         },
         "abilities": [
             "healing"
+        ]
+    },
+    {
+        "name": "Dwarven Warrior",
+        "magic": "eradication",
+        "race": [
+            "dwarf"
+        ],
+        "power": 20,
+        "hp": 160,
+        "a1_power": 200,
+        "a1_type": "melee",
+        "a1_init": 1,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 25,
+            "breath": 0,
+            "magic": 15,
+            "melee": 25,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 10
+        },
+        "abilities": [
+            "racial enemy against orc 50%",
+            "endurance",
+            "recruit speed 30%"
         ]
     },
     {
@@ -1234,46 +1358,6 @@
         ]
     },
     {
-        "name": "Elven Scout",
-        "magic": "verdant",
-        "race": [
-            "elf"
-        ],
-        "power": 20,
-        "hp": 120,
-        "a1_power": 80,
-        "a1_type": "melee",
-        "a1_init": 2,
-        "counter": 30,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "-"
-        ]
-    },
-    {
         "name": "Empyrean Inquisitor",
         "magic": "ascendant",
         "race": [
@@ -1302,7 +1386,7 @@
             "breath": 35,
             "magic": 75,
             "melee": 80,
-            "ranged": 70,
+            "ranged": 80,
             "lightning": 20,
             "cold": 10,
             "paralyse": 0,
@@ -1311,8 +1395,7 @@
         },
         "abilities": [
             "charm",
-            "fear",
-            "weakness to attacktype poison"
+            "fear"
         ]
     },
     {
@@ -1532,7 +1615,7 @@
         ],
         "power": 12,
         "hp": 500,
-        "a1_power": 300,
+        "a1_power": 500,
         "a1_type": "holy",
         "a1_init": 1,
         "counter": 500,
@@ -1688,6 +1771,46 @@
         ]
     },
     {
+        "name": "Gargoyle",
+        "magic": "nether",
+        "race": [
+            "golem"
+        ],
+        "power": 64,
+        "hp": 300,
+        "a1_power": 400,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 25,
+            "phantasm": 15
+        },
+        "resistances": {
+            "missile": 25,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 25,
+            "melee": 25,
+            "ranged": 25,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 100,
+            "holy": 0
+        },
+        "abilities": [
+            "flying"
+        ]
+    },
+    {
         "name": "Ghoul",
         "magic": "nether",
         "race": [
@@ -1707,7 +1830,7 @@
             "verdant": 0,
             "eradication": 0,
             "nether": 0,
-            "phantasm": 25
+            "phantasm": 0
         },
         "resistances": {
             "missile": 0,
@@ -1735,7 +1858,7 @@
             "orc"
         ],
         "power": 13,
-        "hp": 180,
+        "hp": 150,
         "a1_power": 125,
         "a1_type": "melee",
         "a1_init": 1,
@@ -1975,46 +2098,6 @@
         ]
     },
     {
-        "name": "Holy Spirit",
-        "magic": "ascendant",
-        "race": [
-            "elemental"
-        ],
-        "power": 29,
-        "hp": 200,
-        "a1_power": 140,
-        "a1_type": "holy",
-        "a1_init": 1,
-        "counter": 0,
-        "a2_power": 0,
-        "a2_type": "",
-        "a2_init": 0,
-        "spell_resistance": {
-            "ascendant": 0,
-            "verdant": 0,
-            "eradication": 0,
-            "nether": 0,
-            "phantasm": 0
-        },
-        "resistances": {
-            "missile": 0,
-            "fire": 0,
-            "poison": 0,
-            "breath": 0,
-            "magic": 0,
-            "melee": 0,
-            "ranged": 0,
-            "lightning": 0,
-            "cold": 0,
-            "paralyse": 0,
-            "psychic": 0,
-            "holy": 0
-        },
-        "abilities": [
-            "flying"
-        ]
-    },
-    {
         "name": "Horned Demon",
         "magic": "nether",
         "race": [
@@ -2177,6 +2260,47 @@
         },
         "abilities": [
             "flying"
+        ]
+    },
+    {
+        "name": "Knight",
+        "magic": "ascendant",
+        "race": [
+            "human"
+        ],
+        "power": 23,
+        "hp": 200,
+        "a1_power": 250,
+        "a1_type": "melee",
+        "a1_init": 2,
+        "counter": 50,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "large shield",
+            "recruit speed -15%"
         ]
     },
     {
@@ -2554,6 +2678,46 @@
         ]
     },
     {
+        "name": "Minor Elemental",
+        "magic": "phantasm",
+        "race": [
+            "elemental"
+        ],
+        "power": 113,
+        "hp": 600,
+        "a1_power": 400,
+        "a1_type": "poison ranged",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 1000,
+        "a2_type": "lightning ranged",
+        "a2_init": 2,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 0,
+            "phantasm": 35
+        },
+        "resistances": {
+            "missile": 60,
+            "fire": 25,
+            "poison": 100,
+            "breath": 0,
+            "magic": 65,
+            "melee": 60,
+            "ranged": 70,
+            "lightning": 50,
+            "cold": 40,
+            "paralyse": 50,
+            "psychic": 50,
+            "holy": 70
+        },
+        "abilities": [
+            "racial enemy against mindripper 50%"
+        ]
+    },
+    {
         "name": "Naga Queen",
         "magic": "ascendant",
         "race": [
@@ -2642,8 +2806,8 @@
             "giant"
         ],
         "power": 34,
-        "hp": 700,
-        "a1_power": 300,
+        "hp": 300,
+        "a1_power": 400,
         "a1_type": "melee",
         "a1_init": 2,
         "counter": 100,
@@ -2672,7 +2836,6 @@
             "holy": 0
         },
         "abilities": [
-            "clumsiness",
             "endurance",
             "recruit speed 10%"
         ]
@@ -3253,6 +3416,47 @@
         ]
     },
     {
+        "name": "Shadow Elemental",
+        "magic": "nether",
+        "race": [
+            "elemental"
+        ],
+        "power": 444,
+        "hp": 3000,
+        "a1_power": 4500,
+        "a1_type": "paralyse",
+        "a1_init": 1,
+        "counter": 500,
+        "a2_power": 5000,
+        "a2_type": "paralyse ranged",
+        "a2_init": 3,
+        "spell_resistance": {
+            "ascendant": 20,
+            "verdant": 0,
+            "eradication": 25,
+            "nether": 0,
+            "phantasm": 35
+        },
+        "resistances": {
+            "missile": 50,
+            "fire": 25,
+            "poison": 55,
+            "breath": 0,
+            "magic": 45,
+            "melee": 100,
+            "ranged": 45,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 100,
+            "psychic": 30,
+            "holy": 25
+        },
+        "abilities": [
+            "racial enemy against elemental 50%",
+            "swift"
+        ]
+    },
+    {
         "name": "Shadow Monster",
         "magic": "phantasm",
         "race": [
@@ -3624,7 +3828,7 @@
         "name": "Stone Golem",
         "magic": "plain",
         "race": [
-            "human"
+            "golem"
         ],
         "power": 1984,
         "hp": 15000,
@@ -3682,7 +3886,7 @@
             "verdant": 75,
             "eradication": 40,
             "nether": 0,
-            "phantasm": 75
+            "phantasm": 50
         },
         "resistances": {
             "missile": 0,
@@ -3960,6 +4164,88 @@
         ]
     },
     {
+        "name": "Treemaster",
+        "magic": "verdant",
+        "race": [
+            "elf"
+        ],
+        "power": 150,
+        "hp": 750,
+        "a1_power": 2500,
+        "a1_type": "melee poison",
+        "a1_init": 2,
+        "counter": 0,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 80
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 85,
+            "poison": 0,
+            "breath": 0,
+            "magic": 80,
+            "melee": 90,
+            "ranged": 50,
+            "lightning": 20,
+            "cold": 0,
+            "paralyse": 25,
+            "psychic": 25,
+            "holy": 90
+        },
+        "abilities": [
+            "racial enemy against treefolk 50%",
+            "endurance"
+        ]
+    },
+    {
+        "name": "Troglodyte",
+        "magic": "eradication",
+        "race": [
+            "reptile"
+        ],
+        "power": 22,
+        "hp": 160,
+        "a1_power": 200,
+        "a1_type": "poison",
+        "a1_init": 1,
+        "counter": 35,
+        "a2_power": 0,
+        "a2_type": "",
+        "a2_init": 0,
+        "spell_resistance": {
+            "ascendant": 0,
+            "verdant": 0,
+            "eradication": 0,
+            "nether": 0,
+            "phantasm": 0
+        },
+        "resistances": {
+            "missile": 0,
+            "fire": 0,
+            "poison": 0,
+            "breath": 0,
+            "magic": 0,
+            "melee": 0,
+            "ranged": 0,
+            "lightning": 0,
+            "cold": 0,
+            "paralyse": 0,
+            "psychic": 0,
+            "holy": 0
+        },
+        "abilities": [
+            "recruit speed 35%",
+            "scales"
+        ]
+    },
+    {
         "name": "Unholy Reaver",
         "magic": "nether",
         "race": [
@@ -3997,7 +4283,7 @@
         },
         "abilities": [
             "additional strike",
-            "racial enemy against elemental 50%",
+            "racial enemy against elemental 0%",
             "endurance",
             "fear",
             "marksmanship"
@@ -4050,7 +4336,7 @@
         "race": [
             "undead"
         ],
-        "power": 1858,
+        "power": 2058,
         "hp": 4500,
         "a1_power": 9000,
         "a1_type": "magic paralyse",
@@ -4384,7 +4670,7 @@
         "race": [
             "undead"
         ],
-        "power": 130,
+        "power": 160,
         "hp": 1000,
         "a1_power": 2400,
         "a1_type": "magic paralyse",
@@ -4426,7 +4712,7 @@
         "race": [
             "dragon"
         ],
-        "power": 150,
+        "power": 190,
         "hp": 1000,
         "a1_power": 800,
         "a1_type": "melee poison",

--- a/data/slangs.json
+++ b/data/slangs.json
@@ -21,6 +21,9 @@
   "sw": "spirit warrior",
   "naga": "naga queen",
   "nq": "naga queen",
+  "uni": "penishorse",
+  "penishorse":"unicorn",
+
 
   "we": "water elemental",
   "ae": "air elemental",
@@ -32,5 +35,7 @@
   "ee": "earth elemental",
   "he": "high elf",
   "nix": "phoenix",
-  "ebd": "elven blade dancer"
+  "ebd": "elven blade dancer",
+
+  "bullfrog":"frog"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,560 +9,134 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "discord.js": "14.21.0",
+        "discord.js": "^13.7.0",
         "dotenv": "^16.0.1",
-        "lodash": "^4.17.21",
-        "openai": "^5.10.1",
-        "tsx": "^4.19.1"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.188",
-        "typescript": "^4.8.4"
+        "ts-node": "^10.9.1",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.2.tgz",
-      "integrity": "sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==",
-      "license": "Apache-2.0",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.13.0.tgz",
+      "integrity": "sha512-4L9y26KRNNU8Y7J78SRUN1Uhava9D8jfit/YqEaKi8gQRc7PdqKqk2poybo6RXaiyt/BgKYPfcjxT7WvzGfYCA==",
       "dependencies": {
-        "@discordjs/formatters": "^0.6.1",
-        "@discordjs/util": "^1.1.1",
-        "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.1",
+        "@sapphire/shapeshift": "^2.0.0",
+        "@sindresorhus/is": "^4.6.0",
+        "discord-api-types": "^0.31.1",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.4",
-        "tslib": "^2.6.3"
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
+        "node": ">=16.9.0"
       }
+    },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.31.2.tgz",
+      "integrity": "sha512-gpzXTvFVg7AjKVVJFH0oJGC0q0tO34iJGSHZNz9u3aqLxlD6LfxEs9wWVVikJqn9gra940oUTaPFizCkRDcEiA=="
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
-      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
-      "license": "Apache-2.0",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
+      "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w==",
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=16.9.0"
       }
     },
-    "node_modules/@discordjs/formatters": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
-      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
-      "license": "Apache-2.0",
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "dependencies": {
-        "discord-api-types": "^0.38.1"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.1.tgz",
-      "integrity": "sha512-Tg9840IneBcbrAjcGaQzHUJWFNq1MMWZjTdjJ0WS/89IffaNKc++iOvffucPxQTF/gviO9+9r8kEPea1X5J2Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.1.1",
-        "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.3",
-        "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.1",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.3",
-        "undici": "6.21.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
-      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/ws": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
-      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/rest": "^2.5.1",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@types/ws": "^8.5.10",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "^0.38.1",
-        "tslib": "^2.6.2",
-        "ws": "^8.17.0"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
-      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
+      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
-      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "lodash": "^4.17.21"
-      },
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-2.2.0.tgz",
+      "integrity": "sha512-UEnKgMlQyI0yY/q+lCMX0VJft9y86IsesgbIQj6e62FBYSaMVr+IaMNpi4z45Q14VnuMACbK0yrbHISNqgUYcQ==",
       "engines": {
-        "node": ">=v16"
-      }
-    },
-    "node_modules/@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
+        "node": ">=v15.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "node_modules/@types/lodash": {
       "version": "4.14.188",
@@ -571,67 +145,129 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
-      "license": "MIT",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.39.tgz",
+      "integrity": "sha512-JDU3YLlnPK3WDao6/DlXLOgSNpG13ct+CwIO17V8q0/9fWJyeMJJ/VyZ1lv8kDprihvZMydzVwf0tQOqGiY2Nw=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
-    "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
-      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
-      "license": "MIT",
+    "node_modules/acorn": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.18",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.18.tgz",
-      "integrity": "sha512-ygenySjZKUaBf5JT8BNhZSxLzwpwdp41O0wVroOTu/N2DxFH7dxYTZUSnFJ6v+/2F3BMcnD47PC47u4aLOLxrQ==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
+      "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
     },
     "node_modules/discord.js": {
-      "version": "14.21.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.21.0.tgz",
-      "integrity": "sha512-U5w41cEmcnSfwKYlLv5RJjB8Joa+QJyRwIJz5i/eg+v2Qvv6EYpCRhN9I2Rlf0900LuqSDg8edakUATrDZQncQ==",
-      "license": "Apache-2.0",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
+      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
       "dependencies": {
-        "@discordjs/builders": "^1.11.2",
-        "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.6.1",
-        "@discordjs/rest": "^2.5.1",
-        "@discordjs/util": "^1.1.1",
-        "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.1",
-        "fast-deep-equal": "3.1.3",
-        "lodash.snakecase": "4.1.1",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "@discordjs/builders": "^0.13.0",
+        "@discordjs/collection": "^0.6.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.30.0",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.1",
+        "ws": "^8.6.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
+        "node": ">=16.6.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -642,75 +278,22 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.1",
-        "@esbuild/android-arm": "0.23.1",
-        "@esbuild/android-arm64": "0.23.1",
-        "@esbuild/android-x64": "0.23.1",
-        "@esbuild/darwin-arm64": "0.23.1",
-        "@esbuild/darwin-x64": "0.23.1",
-        "@esbuild/freebsd-arm64": "0.23.1",
-        "@esbuild/freebsd-x64": "0.23.1",
-        "@esbuild/linux-arm": "0.23.1",
-        "@esbuild/linux-arm64": "0.23.1",
-        "@esbuild/linux-ia32": "0.23.1",
-        "@esbuild/linux-loong64": "0.23.1",
-        "@esbuild/linux-mips64el": "0.23.1",
-        "@esbuild/linux-ppc64": "0.23.1",
-        "@esbuild/linux-riscv64": "0.23.1",
-        "@esbuild/linux-s390x": "0.23.1",
-        "@esbuild/linux-x64": "0.23.1",
-        "@esbuild/netbsd-x64": "0.23.1",
-        "@esbuild/openbsd-arm64": "0.23.1",
-        "@esbuild/openbsd-x64": "0.23.1",
-        "@esbuild/sunos-x64": "0.23.1",
-        "@esbuild/win32-arm64": "0.23.1",
-        "@esbuild/win32-ia32": "0.23.1",
-        "@esbuild/win32-x64": "0.23.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
-      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
-      "license": "MIT",
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/lodash": {
@@ -718,118 +301,151 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-      "license": "MIT"
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
-    "node_modules/magic-bytes.js": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
-      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
-      "license": "MIT"
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "node_modules/openai": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.10.1.tgz",
-      "integrity": "sha512-fq6xVfv1/gpLbsj8fArEt3b6B9jBxdhAK+VJ+bDvbUvNd+KTLlA3bnDeYZaBsGH9LUhJ1M1yXfp9sEyBLMx6eA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
       },
       "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "encoding": "^0.1.0"
       },
       "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
+        "encoding": {
           "optional": true
         }
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
+      "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/tsx": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.1.tgz",
-      "integrity": "sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==",
-      "license": "MIT",
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "dependencies": {
-        "esbuild": "~0.23.0",
-        "get-tsconfig": "^4.7.5"
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
       },
       "bin": {
-        "tsx": "dist/cli.mjs"
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=18.0.0"
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
       },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
-    "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
-    "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "license": "MIT"
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+        "utf-8-validate": "^5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -839,249 +455,112 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
   },
   "dependencies": {
-    "@discordjs/builders": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.2.tgz",
-      "integrity": "sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==",
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "requires": {
-        "@discordjs/formatters": "^0.6.1",
-        "@discordjs/util": "^1.1.1",
-        "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.1",
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@discordjs/builders": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.13.0.tgz",
+      "integrity": "sha512-4L9y26KRNNU8Y7J78SRUN1Uhava9D8jfit/YqEaKi8gQRc7PdqKqk2poybo6RXaiyt/BgKYPfcjxT7WvzGfYCA==",
+      "requires": {
+        "@sapphire/shapeshift": "^2.0.0",
+        "@sindresorhus/is": "^4.6.0",
+        "discord-api-types": "^0.31.1",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.4",
-        "tslib": "^2.6.3"
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.31.2",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.31.2.tgz",
+          "integrity": "sha512-gpzXTvFVg7AjKVVJFH0oJGC0q0tO34iJGSHZNz9u3aqLxlD6LfxEs9wWVVikJqn9gra940oUTaPFizCkRDcEiA=="
+        }
       }
     },
     "@discordjs/collection": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
-      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
+      "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w=="
     },
-    "@discordjs/formatters": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
-      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "requires": {
-        "discord-api-types": "^0.38.1"
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "@discordjs/rest": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.1.tgz",
-      "integrity": "sha512-Tg9840IneBcbrAjcGaQzHUJWFNq1MMWZjTdjJ0WS/89IffaNKc++iOvffucPxQTF/gviO9+9r8kEPea1X5J2Dw==",
-      "requires": {
-        "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.1.1",
-        "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.3",
-        "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.1",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.3",
-        "undici": "6.21.3"
-      },
-      "dependencies": {
-        "@discordjs/collection": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-          "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="
-        }
-      }
-    },
-    "@discordjs/util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
-      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g=="
-    },
-    "@discordjs/ws": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
-      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
-      "requires": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/rest": "^2.5.1",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@types/ws": "^8.5.10",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "^0.38.1",
-        "tslib": "^2.6.2",
-        "ws": "^8.17.0"
-      },
-      "dependencies": {
-        "@discordjs/collection": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
-          "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="
-        }
-      }
-    },
-    "@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
-      "optional": true
-    },
-    "@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
-      "optional": true
-    },
-    "@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
-      "optional": true
-    },
-    "@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
-      "optional": true
-    },
-    "@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
-      "optional": true
-    },
-    "@esbuild/darwin-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
-      "optional": true
-    },
-    "@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
-      "optional": true
-    },
-    "@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
-      "optional": true
-    },
-    "@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
-      "optional": true
-    },
-    "@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
-      "optional": true
-    },
-    "@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
-      "optional": true
-    },
-    "@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
-      "optional": true
-    },
-    "@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
-      "optional": true
-    },
-    "@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
-      "optional": true
-    },
-    "@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
-      "optional": true
-    },
-    "@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
-      "optional": true
-    },
-    "@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
-      "optional": true
-    },
-    "@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
-      "optional": true
-    },
-    "@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
-      "optional": true
-    },
-    "@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
-      "optional": true
-    },
-    "@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
-      "optional": true
-    },
-    "@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
-      "optional": true
-    },
-    "@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
-      "optional": true
-    },
-    "@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
-      "optional": true
     },
     "@sapphire/async-queue": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
-      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
+      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g=="
     },
     "@sapphire/shapeshift": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
-      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
-      "requires": {
-        "fast-deep-equal": "^3.1.3",
-        "lodash": "^4.17.21"
-      }
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-2.2.0.tgz",
+      "integrity": "sha512-UEnKgMlQyI0yY/q+lCMX0VJft9y86IsesgbIQj6e62FBYSaMVr+IaMNpi4z45Q14VnuMACbK0yrbHISNqgUYcQ=="
     },
-    "@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
+    "@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "@types/lodash": {
       "version": "4.14.188",
@@ -1090,49 +569,106 @@
       "dev": true
     },
     "@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.39.tgz",
+      "integrity": "sha512-JDU3YLlnPK3WDao6/DlXLOgSNpG13ct+CwIO17V8q0/9fWJyeMJJ/VyZ1lv8kDprihvZMydzVwf0tQOqGiY2Nw=="
+    },
+    "@types/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==",
       "requires": {
-        "undici-types": "~7.8.0"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "requires": {
         "@types/node": "*"
       }
     },
-    "@vladfrangu/async_event_emitter": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
-      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA=="
+    "acorn": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "discord-api-types": {
-      "version": "0.38.18",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.18.tgz",
-      "integrity": "sha512-ygenySjZKUaBf5JT8BNhZSxLzwpwdp41O0wVroOTu/N2DxFH7dxYTZUSnFJ6v+/2F3BMcnD47PC47u4aLOLxrQ=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
+      "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
     },
     "discord.js": {
-      "version": "14.21.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.21.0.tgz",
-      "integrity": "sha512-U5w41cEmcnSfwKYlLv5RJjB8Joa+QJyRwIJz5i/eg+v2Qvv6EYpCRhN9I2Rlf0900LuqSDg8edakUATrDZQncQ==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
+      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
       "requires": {
-        "@discordjs/builders": "^1.11.2",
-        "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.6.1",
-        "@discordjs/rest": "^2.5.1",
-        "@discordjs/util": "^1.1.1",
-        "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.1",
-        "fast-deep-equal": "3.1.3",
-        "lodash.snakecase": "4.1.1",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "@discordjs/builders": "^0.13.0",
+        "@discordjs/collection": "^0.6.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.30.0",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.1",
+        "ws": "^8.6.0"
       }
     },
     "dotenv": {
@@ -1140,54 +676,19 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
-    "esbuild": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
-      "requires": {
-        "@esbuild/aix-ppc64": "0.23.1",
-        "@esbuild/android-arm": "0.23.1",
-        "@esbuild/android-arm64": "0.23.1",
-        "@esbuild/android-x64": "0.23.1",
-        "@esbuild/darwin-arm64": "0.23.1",
-        "@esbuild/darwin-x64": "0.23.1",
-        "@esbuild/freebsd-arm64": "0.23.1",
-        "@esbuild/freebsd-x64": "0.23.1",
-        "@esbuild/linux-arm": "0.23.1",
-        "@esbuild/linux-arm64": "0.23.1",
-        "@esbuild/linux-ia32": "0.23.1",
-        "@esbuild/linux-loong64": "0.23.1",
-        "@esbuild/linux-mips64el": "0.23.1",
-        "@esbuild/linux-ppc64": "0.23.1",
-        "@esbuild/linux-riscv64": "0.23.1",
-        "@esbuild/linux-s390x": "0.23.1",
-        "@esbuild/linux-x64": "0.23.1",
-        "@esbuild/netbsd-x64": "0.23.1",
-        "@esbuild/openbsd-arm64": "0.23.1",
-        "@esbuild/openbsd-x64": "0.23.1",
-        "@esbuild/sunos-x64": "0.23.1",
-        "@esbuild/win32-arm64": "0.23.1",
-        "@esbuild/win32-ia32": "0.23.1",
-        "@esbuild/win32-x64": "0.23.1"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "optional": true
-    },
-    "get-tsconfig": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
-      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
-        "resolve-pkg-maps": "^1.0.0"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "lodash": {
@@ -1195,68 +696,106 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-    },
-    "magic-bytes.js": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
-      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="
-    },
-    "openai": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.10.1.tgz",
-      "integrity": "sha512-fq6xVfv1/gpLbsj8fArEt3b6B9jBxdhAK+VJ+bDvbUvNd+KTLlA3bnDeYZaBsGH9LUhJ1M1yXfp9sEyBLMx6eA==",
-      "requires": {}
-    },
-    "resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
-    },
-    "ts-mixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
-    },
-    "tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
-    "tsx": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.1.tgz",
-      "integrity": "sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==",
-      "requires": {
-        "esbuild": "~0.23.0",
-        "fsevents": "~2.3.3",
-        "get-tsconfig": "^4.7.5"
-      }
-    },
-    "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
-    "undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
-    "undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "ts-mixer": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
+      "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
+    },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "typescript": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
       "requires": {}
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,22 +2,28 @@
   "name": "discord-bot",
   "version": "1.0.0",
   "description": "",
-  "main": "build/src/index.js",
+  "main": "build/index.js",
+  "type": "module",
   "scripts": {
-    "build": "./node_modules/.bin/tsc --build",
-    "start": "node --es-module-specifier-resolution=node build/src/index.js"
+    "build": "tsc --build",
+    "start": "node --es-module-specifier-resolution=node build/index.js",
+    "sync:guildwar-units": "node ./src/sync-units.mjs --dataset=guild",
+    "sync:beta-units": "node ./src/sync-units.mjs --dataset=beta",
+    "sync:blitz-units": "node ./src/sync-units.mjs --dataset=blitz",
+    "sync:arch-units": "node ./src/sync-units.mjs --dataset=arch",
+    "sync:lightning-units": "node ./src/sync-units.mjs --dataset=lightning"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "discord.js": "14.21.0",
+    "discord.js": "^13.7.0",
     "dotenv": "^16.0.1",
-    "lodash": "^4.17.21",
-    "openai": "^5.10.1",
-    "tsx": "^4.19.1"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.188",
-    "typescript": "^4.8.4"
-  }
+    "ts-node": "^10.9.1",
+    "typescript": "^5.5.4"
+  },
+  "packageManager": "yarn@3.2.4+sha512.bb197bb586aabeca42ce9113e2235af3edaeac5797d26c99067e58d401d4eb43fbd51b644431434dd2a5f612ee65ffcd20262016c62f3608eb39fbfa6eeb1de7"
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import fs from 'fs';
-import { randomBM, levenshteinDistance } from './util';
-import { calcAccuracy } from './calc-accuracy';
-import { calcResistance } from './calc-resistance';
-import { calcDamageModifiers } from './calc-damage-modifiers';
-import { calcEQ } from './calc-eq';
-import { Unit, Ref, SimResult } from './types';
+import { randomBM, levenshteinDistance } from './util.js';
+import { calcAccuracy } from './calc-accuracy.js';
+import { calcResistance } from './calc-resistance.js';
+import { calcDamageModifiers } from './calc-damage-modifiers.js';
+import { calcEQ } from './calc-eq.js';
+import { Unit, Ref, SimResult } from './types.js';
 
 // TODO
 // - Enchant: hallu
@@ -21,7 +21,19 @@ export const Engine = class {
     this.enchantmentMap = new Map();
   }
 
-  calculateEQ(targetNP: number, targetMana: number, casterNP: number) {
+  _getDefaultEnchantsByMagic(magic: string, defaultEnchantments: any) {
+    if (defaultEnchantments && defaultEnchantments[magic]) {
+      return defaultEnchantments[magic];
+    }
+    if (magic === 'ascendant') return ['lnp', 'thl'];
+    if (magic === 'verdant') return ['pg', 'lore', 'ea'];
+    if (magic === 'eradication') return ['bc'];
+    if (magic === 'nether') return ['bs', 'sod'];
+    if (magic === 'phantasm') return ['hallu'];
+    return [];
+  }
+
+  calculateEQ(casterNP: number, targetNP: number, targetMana: number) {
     return calcEQ(casterNP, targetNP, targetMana);
   }
 
@@ -145,18 +157,14 @@ export const Engine = class {
     });
   }
 
-  _calcEnchantments(attackRef: Ref, defendRef: Ref, serverName: string, attackerEnchants: any, defenderEnchants: any) {
+  _calcEnchantments(attackRef: Ref, defendRef: Ref, serverName: string, attackerEnchants: any, defenderEnchants: any, defaultEnchantments: any) {
     let attackEnchant: string[] = [];
     let defendEnchant: string[] = [];
 
     if (!attackerEnchants || attackerEnchants.length === 0) {
       // Leave the attackEnchant array empty
     } else if (attackerEnchants[0] === 'default') {
-      if (attackRef.magic === 'ascendant') attackEnchant = ['thl', 'lnp'];
-      if (attackRef.magic === 'verdant') attackEnchant = ['ea', 'pg', 'lore'];
-      if (attackRef.magic === 'eradication') attackEnchant = ['bc'];
-      if (attackRef.magic === 'nether') attackEnchant = ['bs'];
-      if (attackRef.magic === 'phantasm') attackEnchant = ['hallu'];
+      attackEnchant = this._getDefaultEnchantsByMagic(attackRef.magic, defaultEnchantments);
     } else {
       attackEnchant = attackerEnchants;
     }
@@ -164,11 +172,7 @@ export const Engine = class {
     if (!defenderEnchants || defenderEnchants.length === 0) {
       // Leave the defendEnchant array empty
     } else if (defenderEnchants[0] === 'default') {
-      if (defendRef.magic === 'ascendant') defendEnchant = ['thl', 'lnp'];
-      if (defendRef.magic === 'verdant') defendEnchant = ['ea', 'pg', 'lore'];
-      if (defendRef.magic === 'eradication') defendEnchant = ['bc'];
-      if (defendRef.magic === 'nether') defendEnchant = ['bs'];
-      if (defendRef.magic === 'phantasm') defendEnchant = ['hallu'];
+      defendEnchant = this._getDefaultEnchantsByMagic(defendRef.magic, defaultEnchantments);
     } else {
       defendEnchant = defenderEnchants; 
     }
@@ -177,6 +181,9 @@ export const Engine = class {
     if (!enchantmentMap) {
       throw `Cannot find enchantment for ${serverName}`;
     }
+
+    attackEnchant = attackEnchant.filter(e => enchantmentMap.has(e));
+    defendEnchant = defendEnchant.filter(e => enchantmentMap.has(e));
 
     for (const e of attackEnchant) {
       this._applyEnchantment(enchantmentMap.get(e), attackRef);
@@ -375,7 +382,7 @@ export const Engine = class {
 
 
   // Main method
-  simulate(attacker: Unit, defender: Unit, serverName: string, attackerEnchants: any , defenderEnchants: any) {
+  simulate(attacker: Unit, defender: Unit, serverName: string, attackerEnchants: any , defenderEnchants: any, defaultEnchantments: any = null) {
     // Allocate approximate number of units at equal net power
     const TOTAL_NP = 2000000;
 
@@ -422,7 +429,7 @@ export const Engine = class {
       if (attackerRef.secondaryInit === 2) attackerRef.secondaryInit = 1;
     }
 
-    this._calcEnchantments(attackerRef, defenderRef, serverName, attackerEnchants, defenderEnchants);
+    this._calcEnchantments(attackerRef, defenderRef, serverName, attackerEnchants, defenderEnchants, defaultEnchantments);
 
     // temp
     let attackRef: Ref | null = null;
@@ -539,17 +546,17 @@ export const Engine = class {
   }
 
   // Run a series of simulations
-  simulateX(attacker: Unit, defender: Unit, serverName: string, attackerEnchants: any, defenderEnchants: any, n: number) {
+  simulateX(attacker: Unit, defender: Unit, serverName: string, attackerEnchants: any, defenderEnchants: any, n: number, defaultEnchantments: any = null) {
     const r: SimResult[] = [];
     for (let i = 0; i < n; i++) {
       r.push(
-        this.simulate(attacker, defender, serverName, attackerEnchants, defenderEnchants)
+        this.simulate(attacker, defender, serverName, attackerEnchants, defenderEnchants, defaultEnchantments)
       );
     }
     return r;
   }
 
-  findPairings(unit: Unit, serverName: string, attackerEnchants: any, defenderEnchants: any) {
+  findPairings(unit: Unit, serverName: string, attackerEnchants: any, defenderEnchants: any, defaultEnchantments: any = null, excludedUnits: string[] = []) {
     const skipList = ['Devil', 'Shadow Monster', 'Succubus'];
 
     const bestAttackers: any[] = [];
@@ -562,8 +569,9 @@ export const Engine = class {
 
     for (const candidate of unitMap.values()) {
       if (skipList.includes(candidate.name)) continue;
+      if (excludedUnits.includes(candidate.name)) continue;
 
-      const results = this.simulateX(candidate, unit, serverName, attackerEnchants, defenderEnchants, N);
+      const results = this.simulateX(candidate, unit, serverName, attackerEnchants, defenderEnchants, N, defaultEnchantments);
       let attackerLoss = 0;
       let defenderLoss = 0;
       for (const r of results) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,11 @@
-// See: https://discord.com/developers/applications
+// https://discord.com/developers/applications
 import * as dotenv from 'dotenv'
 dotenv.config()
 
 import _ from 'lodash';
-import { Client, GatewayIntentBits, Partials } from 'discord.js';
-import { Engine } from './engine';
-import { Unit } from './types';
-import OpenAI from "openai";
-
+import { Client, Intents } from 'discord.js';
+import { Engine } from './engine.js';
+import { Unit } from './types.js';
 
 const engine = new Engine();
 engine.init('./data');
@@ -15,26 +13,44 @@ engine.init('./data');
 
 const client = new Client({
   intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
-    GatewayIntentBits.DirectMessages,
-    GatewayIntentBits.MessageContent
-  ],
-  partials: [Partials.Channel] // Needed for DMs
+    Intents.FLAGS.GUILDS,
+    Intents.FLAGS.GUILD_MESSAGES,
+    Intents.FLAGS.DIRECT_MESSAGES
+  ]
 });
-
-
-const vsVariantsRegex = /(?:vs|versus)/i;
 
 // Assume default
 const DEFAULT_SERVER = 'blitz';
 
 // Allowed enchantments
-const allowedEnchantIds = ['bc', 'bs', 'ea', 'hallu', 'lnp', 'lore', 'pg', 'thl'];
+const allowedEnchantIds = ['bc', 'bs', 'ea', 'hallu', 'lnp', 'lore', 'pg', 'sod', 'thl'];
+const allowedMagicSpecialties = ['ascendant', 'verdant', 'eradication', 'nether', 'phantasm'];
 
+const buildDefaultEnchantments = () => ({
+  ascendant: ['lnp', 'thl'],
+  verdant: ['pg', 'lore', 'ea'],
+  eradication: ['bc'],
+  nether: ['bs', 'sod'],
+  phantasm: ['hallu']
+});
+
+const disabledUnitsByServer = new Map<string, string[]>([
+  ['lightning', ['Duke', 'Dwarven Defender', 'Minor Elemental', 'Shadow Elemental', 'Treemaster']]
+]);
+
+const getDisabledUnitsForServer = (serverName: string) => disabledUnitsByServer.get(serverName) || [];
+const isDisabledUnit = (serverName: string, unitName: string) => {
+  return getDisabledUnitsForServer(serverName).includes(unitName);
+};
+
+let botId = '';
+// annel.send('```' + text + '```');
+// et botTag = '';
 
 client.on('ready', () => {
   console.log(`Logged in as ${client.user?.tag}!`)
+  botId = client.user?.id as string;
+  // botTag = client.user.tag;
 });
 
 const userPrefMap = new Map();
@@ -51,109 +67,63 @@ const logUsage = (...args: string[]) => {
   }
 }
 
-const yyyymmdd = () => {
-  const today = new Date();
-  const yyyy = today.getFullYear();
-  const mm = String(today.getMonth() + 1).padStart(2, '0'); // Months are 0-based
-  const dd = String(today.getDate()).padStart(2, '0');
-  const formattedDate = `${yyyy}-${mm}-${dd}`;
-  return formattedDate;
-}
-const dailyLimitMap: Map<string, number> = new Map<string, number>();
-
-
-const DISCORD_SERVERS = process.env['DISCORD_SERVERS'] ?
-  process.env['DISCORD_SERVERS'].split(',') :
-  [];
-
-
 // Grammar
 // - show unit <unit>
 // - show matchup <unit1> vs <unit2>
-client.on('messageCreate', msg => {
-  if (!msg.mentions.has(client.user as any)) return;
+client.on('message', msg => {
+  const users = msg.mentions.users;
+  if (users.size !== 1 || !users.has(botId)) return; 
 
-  let content = msg.content;
-  content = content.replace(/\<.*\>/, '');
-  content = content.toLowerCase().trim();
+  // Strip only this bot's mention(s). A greedy /<.*>/ removes from first "<" to last ">"
+  // in the whole message and can wipe valid text when Discord adds <#channel>, <:emoji:>, etc.
+  let content = msg.content.toLowerCase().trim();
+  content = content.replace(new RegExp(`<@!?${botId}>`, 'g'), '').trim();
 
   const channel = msg.channel;
   const username = msg.author.username;
+  const userId = msg.author.id;
 
-  if (userPrefMap.has(username) === false) {
-    userPrefMap.set(username, {
-      attackerEnchants: ['default'],
-      defenderEnchants: ['default'],
-      serverName: DEFAULT_SERVER
+  if (userPrefMap.has(userId) === false) {
+    userPrefMap.set(userId, {
+      attackerEnchants: [],
+      defenderEnchants: [],
+      serverName: DEFAULT_SERVER,
+      defaultEnchantments: buildDefaultEnchantments(),
+      allowDisabledUnits: false
     });
   }
 
-  const serverName = userPrefMap.get(username).serverName || DEFAULT_SERVER;
-
-  if (content.startsWith('ask')) {
-
-    if (!msg.guild || DISCORD_SERVERS.includes(msg.guild.id) === false) {
-      channel.send("```AI/LLM not enabled for this server```");
-      return;
-    }
-
-    const q = content.replace('ask', '').trim();
-    const openAIClient = new OpenAI({
-      baseURL: process.env['AI_URL'], // 'https://models.github.ai/inference',
-      apiKey: process.env['AI_TOKEN']
-    });
-    const model = process.env['AI_MODEL'] || 'openai/gpt-4o';
-
-    const dayKey = yyyymmdd();
-    if (dailyLimitMap.has(dayKey) === false) {
-      dailyLimitMap.set(dayKey, 0);
-    }
-
-    if ((dailyLimitMap.get(dayKey) as number) >= 30) {
-      const limitText = 'Exceed daily limit of 30 questions';
-      channel.send("```" + 'md\n' + limitText + "```");
-      return;
-    }
-
-    dailyLimitMap.set(dayKey, (dailyLimitMap.get(dayKey) as number) + 1);
-
-
-    openAIClient.chat.completions.create({
-      messages: [
-        { role: "system", content: "You are a helpful assistant." },
-        { role: "user", content: `Answer the following question in 100 words or less.\n ${q}` }
-      ],
-      temperature: 1.0,
-      top_p: 1.0,
-      max_tokens: 800,
-      model: model
-    }).then(response => {
-      const answer = response.choices[0].message.content;
-      channel.send("```" + 'md\n' + answer + "```");
-    });
-
-    return;
-  }
+  const userPref = userPrefMap.get(userId);
+  const serverName = userPref.serverName || DEFAULT_SERVER;
 
   if (content.startsWith('help')) {
+    const cmd = (text: string) => `\u001b[0;33m${text}\u001b[0m`;
+    const arg = (text: string) => `\u001b[0;36m${text}\u001b[0m`;
 
     const helpText = `
 ### Anansi commands
-show config - Shows your configuration
-set enchant [<e1> <e2> vs <e1> <e2>] - Set enchantments
-  default: set enchant default
-  specify: set enchant none vs <enchant> <enchant>
-  clear all: set enchant
-set server <server> - Select server, e.g. blitz, beta
-show match <unit1> vs <unit2> - Evaluate head-to-head match up
-show pairing <unit> - Evaluate top pairings
-show battle <uni1> vs <unit2> - Single battle with logs
-show eq <targetNP> <targetMP> <casterNP>
 
-if you'd like to contribute or access to the source, see https://github.com/mwdchang/discord-tr-bot
+${cmd('show config')} - Shows your configuration
+${cmd('set enchant')} [${arg('<e1>')} ${arg('<e2>')} ${cmd('vs')} ${arg('<e1>')} ${arg('<e2>')}] - Set enchantments
+${cmd('set default enchant')} ${arg('<specialty>')} ${arg('<e1>')} ${arg('<e2>')} - Set default enchants for magic specialty
+${cmd('show default enchant')} - Show default enchants per specialty
+${cmd('set disabled units')} ${cmd('on|off')} - Include units disabled on selected server (default off)
+  default: set enchant default
+  specify: set enchant none vs ${arg('<enchant>')} ${arg('<enchant>')}
+  clear all: set enchant
+${cmd('set server')} ${arg('<server>')} - Select server, e.g. blitz, guild, beta, arch, lightning
+${cmd('show match')} ${arg('<unit1>')} ${cmd('vs')} ${arg('<unit2>')} - Evaluate head-to-head match up
+${cmd('show pairing')} ${arg('<unit>')} ${cmd('-v')} - Evaluate top pairings (default: head-to-head only, ${cmd('-v')}: full report)
+${cmd('show battle')} ${arg('<uni1>')} ${cmd('vs')} ${arg('<unit2>')} - Single battle with logs
+${cmd('show eq')} ${arg('<casterNP>')} ${arg('<targetNP>')} ${arg('<targetMana>')} - Earthquake: how much mana you need to zero the target
+  ${arg('<casterNP>')} your net power, ${arg('<targetNP>')} their net power, ${arg('<targetMana>')} their current mana (three integers, in that order)
+  reply lists mana by your magic line: eradication, verdant, nether, ascendant, phantasm (pick the line that matches your caster)
+  example: ${cmd('show eq')} 50000 60000 120000
+
+
     `;
 
-    channel.send("```md" + helpText + "```");
+    channel.send("```ansi" + helpText + "```");
     return;
   }
 
@@ -165,62 +135,29 @@ if you'd like to contribute or access to the source, see https://github.com/mwdc
 ${usageText}
     `;
 
-    channel.send('```' + usageReport + '```');
+    channel.send('```' + usageReport+ '```');
     return;
   }
-
+  
   if (content.startsWith('show eq')) {
     const tokens = content.replace('show eq', '').trim().split(' ');
     if (tokens.length !== 3) {
       return;
     }
-    // const targetNP = +tokens[0];
-    // const targetMana = +tokens[1];
-    // const casterNP = +tokens[2];
-
-    let targetNP = +tokens[0];
-    let targetMana = +tokens[1];
-    let casterNP = +tokens[2];
-    let temp = '';
-
-    temp = tokens[0].toLowerCase();
-    if (temp.endsWith('m')) {
-      targetNP = parseFloat(tokens[0]) * 1000000;
-    } else if (temp.endsWith('k')) {
-      targetNP = parseFloat(tokens[0]) * 1000;
-    }
-
-    temp = tokens[1].toLowerCase();
-    if (temp.endsWith('m')) {
-      targetMana = parseFloat(tokens[1]) * 1000000;
-    } else if (temp.endsWith('k')) {
-      targetMana = parseFloat(tokens[1]) * 1000;
-    }
-
-    temp = tokens[2].toLowerCase();
-    if (temp.endsWith('m')) {
-      casterNP = parseFloat(tokens[2]) * 1000000;
-    } else if (temp.endsWith('k')) {
-      casterNP = parseFloat(tokens[2]) * 1000;
-    }
-
-    const r = engine.calculateEQ(targetNP, targetMana, casterNP);
-
-    // round to 1000s, easer to read
-    const round1000 = (v: number) => Math.round(v / 1000) * 1000;
+    const casterNP = +tokens[0];
+    const targetNP = +tokens[1];
+    const targetMana = +tokens[2];
+    const r = engine.calculateEQ(casterNP, targetNP, targetMana);
 
     const reportText = `
 ### Report - ${serverName}
-Earthquake calculation (includes casting cost)
+Earthquake calculation
 
-Target NP: ${targetNP}
-Target Mana: ${targetMana}
-Caster NP: ${casterNP}
-
-Mana required (rounded to closest 1000's)
-Eradication: ${round1000(r.eradication)}
-Verdant/Nether: ${round1000(r.verdant)}
-Ascendant/Phantasm: ${round1000(r.ascendant)}
+Eradication: ${r.eradication}
+Verdant: ${r.verdant}
+Nether: ${r.nether}
+Ascendant: ${r.ascendant}
+Phantasm: ${r.phantasm}
    `;
     channel.send("```" + 'md\n' + reportText + "```");
     return;
@@ -228,66 +165,121 @@ Ascendant/Phantasm: ${round1000(r.ascendant)}
 
   if (content.startsWith('set server')) {
     const server = content.replace('set server', '').trim();
-    if (server !== 'blitz' && server !== 'beta') {
+    if (server !== 'blitz' && server !== 'guild' && server !== 'beta' && server !== 'arch' && server !== 'lightning') {
       channel.send(`Server ${server} is not currently supported`);
       return;
     }
-    userPrefMap.get(username).serverName = server;
+    userPrefMap.get(userId).serverName = server;
     const text = `Set server to ${server} for ${username}`;
     channel.send('```' + text + '```');
     return;
   }
 
   if (content.startsWith('set enchant')) {
-    const tokens = content.replace('set enchant', '').split(vsVariantsRegex);
+    const tokens = content.replace('set enchant', '').split('vs');
 
     // Use default enchantments
     if (!tokens || (tokens.length === 1 && tokens[0].includes('default'))) {
-      userPrefMap.get(username).attackerEnchants = ['default'];
-      userPrefMap.get(username).defenderEnchants = ['default'];
-      channel.send(`${username} using default enchantments`);
+      userPrefMap.get(userId).attackerEnchants = ['default'];
+      userPrefMap.get(userId).defenderEnchants = ['default'];
+      channel.send(`${username} using default enchantments`); 
       return;
     }
 
     // Clear enchantments
     if (tokens.length !== 2) {
-      userPrefMap.get(username).attackerEnchants = [];
-      userPrefMap.get(username).defenderEnchants = [];
-      channel.send(`${username} cleared enchantments`);
+      userPrefMap.get(userId).attackerEnchants = [];
+      userPrefMap.get(userId).defenderEnchants = [];
+      channel.send(`${username} cleared enchantments`); 
       return;
     }
 
     // Set custom enchantments
     const attackerEnchants = tokens[0].split(/[\s,]/).filter(d => d != '');
     const defenderEnchants = tokens[1].split(/[\s,]/).filter(d => d != '');
-
+    
     // Filter out any enchantments that don't exist
     const filteredAttackerEnchants: string[] = attackerEnchants
       .filter(element => allowedEnchantIds.includes(element.toLowerCase()));
     const filteredDefenderEnchants: string[] = defenderEnchants
       .filter(element => allowedEnchantIds.includes(element.toLowerCase()));
 
-    userPrefMap.get(username).attackerEnchants = filteredAttackerEnchants;
-    userPrefMap.get(username).defenderEnchants = filteredDefenderEnchants;
+    userPrefMap.get(userId).attackerEnchants = filteredAttackerEnchants;
+    userPrefMap.get(userId).defenderEnchants = filteredDefenderEnchants;
 
     channel.send(`${username}: attacker=${filteredAttackerEnchants.join(' ')} defender=${filteredDefenderEnchants.join(' ')}`);
     return;
   }
 
+  if (content.startsWith('set disabled units')) {
+    const value = content.replace('set disabled units', '').trim();
+    if (value !== 'on' && value !== 'off') {
+      channel.send('Usage: set disabled units <on|off>');
+      return;
+    }
+    userPrefMap.get(userId).allowDisabledUnits = value === 'on';
+    channel.send(`${username}: disabled units ${value === 'on' ? 'enabled' : 'disabled'}`);
+    return;
+  }
+
+  if (content.startsWith('show default enchant')) {
+    const defaults = userPrefMap.get(userId).defaultEnchantments;
+    const text = `
+### Default enchantments (${username})
+ascendant = ${defaults.ascendant.join(' ')}
+verdant = ${defaults.verdant.join(' ')}
+eradication = ${defaults.eradication.join(' ')}
+nether = ${defaults.nether.join(' ')}
+phantasm = ${defaults.phantasm.join(' ')}
+    `;
+    channel.send('```' + text + '```');
+    return;
+  }
+
+  if (content.startsWith('set default enchant')) {
+    const rest = content.replace('set default enchant', '').trim();
+    const tokens = rest.split(/[\s,]+/).filter(t => t !== '');
+    const specialty = tokens[0];
+    if (!specialty || !allowedMagicSpecialties.includes(specialty)) {
+      channel.send(`Usage: set default enchant <${allowedMagicSpecialties.join('|')}> <none|default|${allowedEnchantIds.join('|')}>...`);
+      return;
+    }
+
+    const defaults = userPrefMap.get(userId).defaultEnchantments;
+    const values = tokens.slice(1).map(t => t.toLowerCase());
+    if (values.length === 0 || values.includes('none')) {
+      defaults[specialty] = [];
+      channel.send(`${username}: default ${specialty} enchantments cleared`);
+      return;
+    }
+    if (values.includes('default')) {
+      defaults[specialty] = buildDefaultEnchantments()[specialty];
+      channel.send(`${username}: default ${specialty} enchantments reset to system default (${defaults[specialty].join(' ')})`);
+      return;
+    }
+
+    const filtered = values.filter(element => allowedEnchantIds.includes(element));
+    defaults[specialty] = [...new Set(filtered)];
+    channel.send(`${username}: default ${specialty} enchantments=${defaults[specialty].join(' ')}`);
+    return;
+  }
+
   if (content.startsWith('show config')) {
-    const userPref = userPrefMap.get(username);
     const configText = `
 ### Configuration for ${username}
 attacker enchantments = ${userPref.attackerEnchants.join(', ')}
 defender enchantments = ${userPref.defenderEnchants.join(', ')}
 server = ${userPref.serverName}
+include disabled units = ${userPref.allowDisabledUnits ? 'on' : 'off'}
     `;
     channel.send('```' + configText + '```');
     return;
   }
 
   if (content.startsWith('show pairing')) {
-    const uStr = content.replace('show pairing', '').trim();
+    const rawPairingArg = content.replace('show pairing', '').trim();
+    const verbose = rawPairingArg.includes(' -v');
+    const uStr = rawPairingArg.replace(' -v', '').trim();
     const u = engine.findUnit(uStr, serverName);
 
 
@@ -295,12 +287,18 @@ server = ${userPref.serverName}
       channel.send(`I cannot find "${uStr}"`);
       return;
     }
+    if (!userPref.allowDisabledUnits && isDisabledUnit(serverName, u.name)) {
+      channel.send(`"${u.name}" is disabled on ${serverName}. Use "set disabled units on" to include disabled units.`);
+      return;
+    }
 
     logUsage(u.name);
 
-    const attackerEnchants = userPrefMap.get(username).attackerEnchants;
-    const defenderEnchants = userPrefMap.get(username).defenderEnchants;
-    const r = engine.findPairings(u, serverName, attackerEnchants, defenderEnchants);
+    const attackerEnchants = userPrefMap.get(userId).attackerEnchants;
+    const defenderEnchants = userPrefMap.get(userId).defenderEnchants;
+    const defaultEnchantments = userPrefMap.get(userId).defaultEnchantments;
+    const excludedUnits = userPref.allowDisabledUnits ? [] : getDisabledUnitsForServer(serverName);
+    const r = engine.findPairings(u, serverName, attackerEnchants, defenderEnchants, defaultEnchantments, excludedUnits);
 
     if (!r) return;
 
@@ -331,7 +329,7 @@ server = ${userPref.serverName}
     const T_viable = 2000000 * 0.05;
 
     [
-      topAttackerAscendant,
+      topAttackerAscendant, 
       topAttackerVerdant,
       topAttackerEradication,
       topAttackerNether,
@@ -344,7 +342,7 @@ server = ${userPref.serverName}
 
 
     [
-      topViableAscendant,
+      topViableAscendant, 
       topViableVerdant,
       topViableEradication,
       topViableNether,
@@ -356,7 +354,7 @@ server = ${userPref.serverName}
     });
 
     [
-      topDefenderAscendant,
+      topDefenderAscendant, 
       topDefenderVerdant,
       topDefenderEradication,
       topDefenderNether,
@@ -400,14 +398,27 @@ Phantasm: ${topViablePhantasm.map(d => d.name).join(', ')}
 ^ Deals 5% or more damage than it receives (good head-to-head)
     `;
 
+    const conciseReportText = `
+### Report - ${serverName}
+
+#### Top head-to-head viable units:
+Ascendant: ${topViableAscendant.map(d => d.name).join(', ')}
+Verdant: ${topViableVerdant.map(d => d.name).join(', ')}
+Eradication: ${topViableEradication.map(d => d.name).join(', ')}
+Nether: ${topViableNether.map(d => d.name).join(', ')}
+Phantasm: ${topViablePhantasm.map(d => d.name).join(', ')}
+
+^ Deals 5% or more damage than it receives (good head-to-head)
+    `;
+
     const header = `Pairing against ${u.name} - **${serverName}**`;
-    channel.send(header + "```" + 'md\n' + reportText + "```");
+    channel.send(header + "```" + 'md\n' + (verbose ? reportText : conciseReportText) + "```");
     return;
   }
 
 
   if (content.startsWith('show battle')) {
-    const tokens = content.replace('show battle', '').split(vsVariantsRegex);
+    const tokens = content.replace('show battle', '').split('vs');
 
     let u1str = '';
     let u2str = '';
@@ -428,18 +439,27 @@ Phantasm: ${topViablePhantasm.map(d => d.name).join(', ')}
       channel.send(`I cannot find "${tokens[0]}"`);
       return;
     }
+    if (!userPref.allowDisabledUnits && isDisabledUnit(serverName, u1.name)) {
+      channel.send(`"${u1.name}" is disabled on ${serverName}. Use "set disabled units on" to include disabled units.`);
+      return;
+    }
     if (!u2) {
       channel.send(`I cannot find "${tokens[1]}"`);
+      return;
+    }
+    if (!userPref.allowDisabledUnits && isDisabledUnit(serverName, u2.name)) {
+      channel.send(`"${u2.name}" is disabled on ${serverName}. Use "set disabled units on" to include disabled units.`);
       return;
     }
 
     if (u1 && u2) {
       logUsage(u1.name, u2.name);
 
-      const attackerEnchants = userPrefMap.get(username).attackerEnchants;
-      const defenderEnchants = userPrefMap.get(username).defenderEnchants;
+      const attackerEnchants = userPrefMap.get(userId).attackerEnchants;
+      const defenderEnchants = userPrefMap.get(userId).defenderEnchants;
+      const defaultEnchantments = userPrefMap.get(userId).defaultEnchantments;
 
-      const r = engine.simulate(u1, u2, serverName, attackerEnchants, defenderEnchants);
+      const r = engine.simulate(u1, u2, serverName, attackerEnchants, defenderEnchants, defaultEnchantments);
       const battleLog = r.battleLog;
 
       let attackercount = r.attackerUnitCount;
@@ -457,7 +477,7 @@ ${battleLog.join('\n')}
   }
 
   if (content.startsWith('show match')) {
-    const tokens = content.replace('show match', '').split(vsVariantsRegex);
+    const tokens = content.replace('show match', '').split('vs');
 
     let u1str = '';
     let u2str = '';
@@ -479,8 +499,16 @@ ${battleLog.join('\n')}
       channel.send(`I cannot find "${tokens[0]}"`);
       return;
     }
+    if (!userPref.allowDisabledUnits && isDisabledUnit(serverName, u1.name)) {
+      channel.send(`"${u1.name}" is disabled on ${serverName}. Use "set disabled units on" to include disabled units.`);
+      return;
+    }
     if (!u2) {
       channel.send(`I cannot find "${tokens[1]}"`);
+      return;
+    }
+    if (!userPref.allowDisabledUnits && isDisabledUnit(serverName, u2.name)) {
+      channel.send(`"${u2.name}" is disabled on ${serverName}. Use "set disabled units on" to include disabled units.`);
       return;
     }
 
@@ -489,10 +517,11 @@ ${battleLog.join('\n')}
     if (u1 && u2) {
       logUsage(u1.name, u2.name);
 
-      const attackerEnchants = userPrefMap.get(username).attackerEnchants;
-      const defenderEnchants = userPrefMap.get(username).defenderEnchants;
+      const attackerEnchants = userPrefMap.get(userId).attackerEnchants;
+      const defenderEnchants = userPrefMap.get(userId).defenderEnchants;
+      const defaultEnchantments = userPrefMap.get(userId).defaultEnchantments;
 
-      const results = engine.simulateX(u1, u2, serverName, attackerEnchants, defenderEnchants, N);
+      const results = engine.simulateX(u1, u2, serverName, attackerEnchants, defenderEnchants, N, defaultEnchantments);
       let attackerloss = 0;
       let attackerunit = 0;
       let defenderloss = 0;
@@ -508,9 +537,9 @@ ${battleLog.join('\n')}
         defenderunit += r.defenderUnitLoss;
 
         if (noNeg(r.defenderLoss) / noNeg(r.attackerLoss) > 1.1) {
-          wins++;
+          wins ++;
         } else if (noNeg(r.attackerLoss) / noNeg(r.defenderLoss) > 1.1) {
-          losses++;
+          losses ++;
         }
       }
       let ties = N - wins - losses;
@@ -519,7 +548,7 @@ ${battleLog.join('\n')}
       attackerunit /= N;
       defenderloss /= N;
       defenderunit /= N;
-
+      
       let attackercount = results[0].attackerUnitCount;
       let defendercount = results[0].defenderUnitCount;
       const attacker = results[0].attacker;

--- a/src/sync-units.mjs
+++ b/src/sync-units.mjs
@@ -1,0 +1,458 @@
+import fs from 'fs';
+import path from 'path';
+import https from 'https';
+import { fileURLToPath } from 'url';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_OUTPUT_PATH = path.join(ROOT_DIR, 'data', 'guild', 'units.json');
+const WIKI_API = 'https://wiki.the-reincarnation.org/api.php';
+const DATASETS = {
+  guild: {
+    categoryTitle: 'Category:Units_(Guildwar)',
+    titlePrefix: 'Guildwar',
+    defaultOutputPath: path.join(ROOT_DIR, 'data', 'guild', 'units.json'),
+    ignoredUnits: new Set(['Assassin', 'Capsule Monster', 'Iron Golem'])
+  },
+  beta: {
+    categoryTitle: 'Category:Units_(Beta)',
+    titlePrefix: 'Beta',
+    defaultOutputPath: path.join(ROOT_DIR, 'data', 'beta', 'units.json'),
+    ignoredUnits: new Set(['Capsule Monster', 'Call Venus Flytraps'])
+  },
+  blitz: {
+    categoryTitle: 'Category:Units_(Blitz)',
+    titlePrefix: 'Blitz',
+    defaultOutputPath: path.join(ROOT_DIR, 'data', 'blitz', 'units.json'),
+    ignoredUnits: new Set(['Assassin', 'Capsule Monster', 'Iron Golem'])
+  },
+  arch: {
+    categoryTitle: 'Category:Units_(Arch)',
+    titlePrefix: 'Arch',
+    defaultOutputPath: path.join(ROOT_DIR, 'data', 'arch', 'units.json'),
+    ignoredUnits: new Set(['Capsule Monster', 'Unholy Reaver', 'Elven Blade Dancer', 'Phantom'])
+  },
+  lightning: {
+    categoryTitle: 'Category:Units_(Lightning)',
+    titlePrefix: 'Lightning',
+    defaultOutputPath: path.join(ROOT_DIR, 'data', 'lightning', 'units.json'),
+    ignoredUnits: new Set(['Assassin', 'Capsule Monster', 'Call Venus Flytraps', 'Iron Golem'])
+  }
+};
+
+const MAGIC_MAP = {
+  ascendant: 'ascendant',
+  verdant: 'verdant',
+  eradication: 'eradication',
+  nether: 'nether',
+  phantasm: 'phantasm',
+  plain: 'plain'
+};
+
+const RACE_MAP = {
+  angel: 'angel',
+  animal: 'animal',
+  astral: 'astral',
+  demon: 'demon',
+  dragon: 'dragon',
+  dwarf: 'dwarf',
+  elemental: 'elemental',
+  elf: 'elf',
+  giant: 'giant',
+  golem: 'golem',
+  human: 'human',
+  illusion: 'illusion',
+  orc: 'orc',
+  pixie: 'pixie',
+  reptile: 'reptile',
+  telepath: 'telepath',
+  treefolk: 'treefolk',
+  troll: 'troll',
+  undead: 'undead'
+};
+
+const TYPE_MAP = {
+  melee: 'melee',
+  missile: 'missile',
+  ranged: 'ranged',
+  magic: 'magic',
+  fire: 'fire',
+  poison: 'poison',
+  breath: 'breath',
+  lightning: 'lightning',
+  cold: 'cold',
+  paralyse: 'paralyse',
+  paralyze: 'paralyse',
+  psychic: 'psychic',
+  holy: 'holy'
+};
+
+const RESISTANCE_KEYS = ['missile', 'fire', 'poison', 'breath', 'magic', 'melee', 'ranged', 'lightning', 'cold', 'paralyse', 'psychic', 'holy'];
+
+const SPELL_RESIST_MAP = {
+  white: 'ascendant',
+  green: 'verdant',
+  red: 'eradication',
+  black: 'nether',
+  blue: 'phantasm'
+};
+
+class DisabledUnitError extends Error {
+  constructor(unitName, titlePrefix) {
+    super(`Unit is disabled on ${titlePrefix} server`);
+    this.name = 'DisabledUnitError';
+    this.unitName = unitName;
+    this.titlePrefix = titlePrefix;
+  }
+}
+
+async function fetchHistoricalStatsRaw(statsTitle) {
+  const historyUrl = `${WIKI_API}?${new URLSearchParams({
+    action: 'query',
+    prop: 'revisions',
+    titles: statsTitle,
+    rvprop: 'ids|timestamp|content',
+    rvlimit: '50',
+    format: 'json'
+  }).toString()}`;
+  const body = await httpGet(historyUrl);
+  const payload = JSON.parse(body);
+  const pages = payload?.query?.pages || {};
+  const page = Object.values(pages)[0];
+  const revisions = page?.revisions || [];
+
+  for (const revision of revisions) {
+    const content = revision['*'] || '';
+    if (typeof content === 'string' && content.includes('UnitBaseStats')) {
+      return content;
+    }
+  }
+  return null;
+}
+
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+          return;
+        }
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => resolve(body));
+      })
+      .on('error', reject);
+  });
+}
+
+function toApiUrl(params) {
+  const p = new URLSearchParams(params);
+  return `${WIKI_API}?${p.toString()}`;
+}
+
+function parseNumber(value, fallback = 0) {
+  if (!value) return fallback;
+  const cleaned = value.replaceAll(',', '').replaceAll('%', '').trim();
+  const match = cleaned.match(/-?\d+(\.\d+)?/);
+  if (!match) return fallback;
+  return Number(match[0]);
+}
+
+function stripWikiMarkup(value) {
+  if (!value) return '';
+  let s = value;
+  s = s.replace(/<!--[\s\S]*?-->/g, '');
+  s = s.replace(/\[\[([^|\]]+)\|([^\]]+)\]\]/g, '$2');
+  s = s.replace(/\[\[([^\]]+)\]\]/g, '$1');
+  s = s.replace(/\{\{[^{}]*\}\}/g, '');
+  s = s.replace(/'''?/g, '');
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = s.replace(/&nbsp;/g, ' ');
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeAttackTypes(value) {
+  const tokens = stripWikiMarkup(value)
+    .toLowerCase()
+    .split(/[\s,/]+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const mapped = [];
+  for (const token of tokens) {
+    const mappedToken = TYPE_MAP[token];
+    if (mappedToken && !mapped.includes(mappedToken)) {
+      mapped.push(mappedToken);
+    }
+  }
+  return mapped.join(' ');
+}
+
+function normalizeAbility(value) {
+  return stripWikiMarkup(value).toLowerCase();
+}
+
+function parseTemplateFields(raw) {
+  const lines = raw.split('\n');
+  const fields = {};
+  for (const line of lines) {
+    const m = line.match(/^\|\s*([^=]+?)\s*=\s*(.*)$/);
+    if (!m) continue;
+    fields[m[1].trim().toLowerCase()] = m[2].trim();
+  }
+  return fields;
+}
+
+function parseAbilities(rawAbility) {
+  if (!rawAbility) return [];
+  return rawAbility
+    .split(',')
+    .map((part) => normalizeAbility(part))
+    .filter(Boolean);
+}
+
+function parseRace(rawRace) {
+  const races = stripWikiMarkup(rawRace)
+    .toLowerCase()
+    .split(/[\s,/]+/)
+    .map((r) => r.trim())
+    .filter(Boolean)
+    .map((r) => RACE_MAP[r])
+    .filter(Boolean);
+
+  if (races.length > 0) return [...new Set(races)];
+  return ['human'];
+}
+
+function parseMagic(rawColor) {
+  const normalized = stripWikiMarkup(rawColor).toLowerCase();
+  return MAGIC_MAP[normalized] || 'plain';
+}
+
+function toUnitName(title, titlePrefix) {
+  const n = title.replace(`${titlePrefix}:`, '').replace(' (Unit)', '').trim();
+  return n;
+}
+
+function toStatsTitle(unitName, titlePrefix) {
+  return `${titlePrefix}:${unitName.replaceAll(' ', '_')}_(Stats)`;
+}
+
+function parseUnitFromFields(fields, fallbackName) {
+  const name = stripWikiMarkup(fields.name) || fallbackName;
+  const unit = {
+    name,
+    magic: parseMagic(fields.color || ''),
+    race: parseRace(fields.race || ''),
+    power: parseNumber(fields.power),
+    hp: parseNumber(fields.hp),
+    a1_power: parseNumber(fields.ap),
+    a1_type: normalizeAttackTypes(fields.type || ''),
+    a1_init: parseNumber(fields.init),
+    counter: parseNumber(fields.counter),
+    a2_power: parseNumber(fields.xap),
+    a2_type: normalizeAttackTypes(fields.xtype || ''),
+    a2_init: parseNumber(fields.xinit),
+    spell_resistance: {
+      ascendant: 0,
+      verdant: 0,
+      eradication: 0,
+      nether: 0,
+      phantasm: 0
+    },
+    resistances: {
+      missile: 0,
+      fire: 0,
+      poison: 0,
+      breath: 0,
+      magic: 0,
+      melee: 0,
+      ranged: 0,
+      lightning: 0,
+      cold: 0,
+      paralyse: 0,
+      psychic: 0,
+      holy: 0
+    },
+    abilities: parseAbilities(fields.ability || '')
+  };
+
+  for (const [wikiKey, targetKey] of Object.entries(SPELL_RESIST_MAP)) {
+    unit.spell_resistance[targetKey] = parseNumber(fields[wikiKey], 0);
+  }
+
+  for (const rk of RESISTANCE_KEYS) {
+    unit.resistances[rk] = parseNumber(fields[rk], 0);
+  }
+
+  return unit;
+}
+
+function stableStringify(value) {
+  return JSON.stringify(value);
+}
+
+function buildDiff(oldUnit, newUnit) {
+  const diffs = [];
+  for (const k of Object.keys(newUnit)) {
+    const before = stableStringify(oldUnit[k]);
+    const after = stableStringify(newUnit[k]);
+    if (before !== after) {
+      diffs.push(k);
+    }
+  }
+  return diffs;
+}
+
+async function fetchUnitNames(categoryTitle, titlePrefix) {
+  const names = new Set();
+  let cmcontinue = null;
+
+  do {
+    const url = toApiUrl({
+      action: 'query',
+      list: 'categorymembers',
+      cmtitle: categoryTitle,
+      cmlimit: 'max',
+      format: 'json',
+      ...(cmcontinue ? { cmcontinue } : {})
+    });
+    const body = await httpGet(url);
+    const payload = JSON.parse(body);
+    const members = payload?.query?.categorymembers || [];
+    for (const member of members) {
+      if (!String(member.title).startsWith(`${titlePrefix}:`)) continue;
+      names.add(toUnitName(member.title, titlePrefix));
+    }
+    cmcontinue = payload?.continue?.cmcontinue || null;
+  } while (cmcontinue);
+
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+async function fetchUnitStats(unitName, titlePrefix) {
+  const statsTitle = toStatsTitle(unitName, titlePrefix);
+  const url = `https://wiki.the-reincarnation.org/index.php?title=${encodeURIComponent(statsTitle)}&action=raw`;
+  let raw = await httpGet(url);
+  if (raw.toLowerCase().includes(`disable on ${titlePrefix.toLowerCase()} server`)) {
+    const historicalRaw = await fetchHistoricalStatsRaw(statsTitle);
+    if (historicalRaw) {
+      raw = historicalRaw;
+    } else {
+      throw new DisabledUnitError(unitName, titlePrefix);
+    }
+  }
+  if (!raw.includes('UnitBaseStats')) {
+    throw new Error(`No UnitBaseStats template found for ${unitName}`);
+  }
+  const fields = parseTemplateFields(raw);
+  return parseUnitFromFields(fields, unitName);
+}
+
+async function main() {
+  const datasetArg = process.argv.find((arg) => arg.startsWith('--dataset='));
+  const datasetName = datasetArg ? datasetArg.replace('--dataset=', '') : 'guild';
+  const dataset = DATASETS[datasetName];
+  if (!dataset) {
+    throw new Error(`Unknown dataset "${datasetName}". Valid options: ${Object.keys(DATASETS).join(', ')}`);
+  }
+
+  const outputPathArg = process.argv.find((arg) => arg.startsWith('--output='));
+  const outputPath = outputPathArg
+    ? path.resolve(ROOT_DIR, outputPathArg.replace('--output=', ''))
+    : dataset.defaultOutputPath;
+
+  const rawJson = fs.readFileSync(outputPath, 'utf8');
+  const existingUnits = JSON.parse(rawJson);
+  const existingByName = new Map(existingUnits.map((u) => [u.name, u]));
+
+  console.log(`Loaded ${existingUnits.length} local units from ${outputPath}`);
+  const unitNames = (await fetchUnitNames(dataset.categoryTitle, dataset.titlePrefix))
+    .filter((name) => !dataset.ignoredUnits.has(name));
+  console.log(`Fetched ${unitNames.length} ${dataset.titlePrefix} unit titles from wiki (after ignore list)`);
+
+  const fetchedUnits = [];
+  const fetchErrors = [];
+  const disabledUnits = [];
+  for (const unitName of unitNames) {
+    try {
+      const unit = await fetchUnitStats(unitName, dataset.titlePrefix);
+      fetchedUnits.push(unit);
+    } catch (error) {
+      if (error instanceof DisabledUnitError) {
+        disabledUnits.push(unitName);
+      } else {
+        fetchErrors.push({ unitName, error: String(error) });
+      }
+    }
+  }
+
+  if (fetchErrors.length > 0) {
+    console.log(`Warnings: failed to parse ${fetchErrors.length} unit stats pages`);
+    for (const e of fetchErrors.slice(0, 30)) {
+      console.log(`  - ${e.unitName}: ${e.error}`);
+    }
+  }
+  if (disabledUnits.length > 0) {
+    console.log(`Skipped ${disabledUnits.length} disabled units on ${dataset.titlePrefix}: ${disabledUnits.join(', ')}`);
+  }
+
+  const fetchedByName = new Map(fetchedUnits.map((u) => [u.name, u]));
+  const missingInLocal = fetchedUnits.filter((u) => !existingByName.has(u.name)).map((u) => u.name);
+  const missingOnWiki = existingUnits
+    .filter((u) => !fetchedByName.has(u.name) && !dataset.ignoredUnits.has(u.name))
+    .map((u) => u.name);
+
+  const changed = [];
+  for (const unit of fetchedUnits) {
+    if (!existingByName.has(unit.name)) continue;
+    const oldUnit = existingByName.get(unit.name);
+    const diffFields = buildDiff(oldUnit, unit);
+    if (diffFields.length > 0) {
+      changed.push({ name: unit.name, diffFields });
+    }
+  }
+
+  const mergedByName = new Map(
+    existingUnits
+      .filter((u) => unitNames.includes(u.name) || dataset.ignoredUnits.has(u.name))
+      .map((u) => [u.name, u])
+  );
+  for (const unit of fetchedUnits) {
+    mergedByName.set(unit.name, unit);
+  }
+
+  const updatedUnits = [...mergedByName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  fs.writeFileSync(outputPath, `${JSON.stringify(updatedUnits, null, 4)}\n`, 'utf8');
+
+  console.log(`\nSync report`);
+  console.log(`- Wiki units parsed: ${fetchedUnits.length}`);
+  console.log(`- Added locally: ${missingInLocal.length}`);
+  console.log(`- Updated locally: ${changed.length}`);
+  console.log(`- Local-only units (not on wiki list): ${missingOnWiki.length}`);
+
+  if (missingInLocal.length > 0) {
+    console.log('\nAdded units:');
+    for (const n of missingInLocal) console.log(`  - ${n}`);
+  }
+  if (changed.length > 0) {
+    console.log('\nUpdated units (fields changed):');
+    for (const c of changed.slice(0, 60)) {
+      console.log(`  - ${c.name}: ${c.diffFields.join(', ')}`);
+    }
+    if (changed.length > 60) {
+      console.log(`  ... and ${changed.length - 60} more`);
+    }
+  }
+  if (missingOnWiki.length > 0) {
+    console.log('\nLocal-only units:');
+    for (const n of missingOnWiki) console.log(`  - ${n}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,32 +1,23 @@
 {
 	"compilerOptions": {
-		"allowJs": true,
-		"composite": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"isolatedModules": true,
+		"lib": ["ES2021.String"],
+		"module": "ESNext",
 		"moduleResolution": "node",
-		// "module": "ESNext",
 		"noImplicitAny": false,
 		"noImplicitReturns": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		// "outDir": "build",
+		"outDir": "build",
+		"rootDir": "src",
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"lib": [
-			"ES2021.String"
-		],
 		"target": "ESNext"
 	},
-  "include": [
-    "src/*.js",
-    "src/*.ts",
-    "src/*.d.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
Data: Added data/arch, data/guild, data/lightning (units + enchantments); updated data/beta, data/blitz
Sync: Added src/sync-units.mjs and npm scripts to sync units per server.
Bot / engine: EQ via show eq (wired to calc-eq), fixed arg order + report fields; mention parsing (strip only the bot’s <@…>); pairing / default enchants / disabled-units behavior (this is admittedly dumb); help lists show eq 
Build: tsconfig emits to build/; package.json start/main → build/index.js (was wrongly using stale build/src/index.js). .gitignore ignores accidental src/*.js emit; keep src/types.d.ts.